### PR TITLE
graphML Syntactic Checker: General graphML Syntax Error

### DIFF
--- a/server/controllers/importers/graphml.js
+++ b/server/controllers/importers/graphml.js
@@ -7,10 +7,11 @@ var graphmlWarnings = {
   EDGES_WITHOUT_WEIGHTS: {
     warningCode: "EDGES_WITHOUT_WEIGHTS",
     errorDescription: "GRNsight has detected that one or more edges in your network are missing numerical weight" +
-    " values. Because the algorithm GRNsight uses for determining the arrowhead type and the color and thickness of" +
-    " the edges requires numerical weight values, your graph will display as an unweighted graph with black edges" +
-    " and pointed arrowheads. If you want to display the network as a weighted graph, please modify your input file" +
-    " to include weight values for all edges."
+                      " values. Because the algorithm GRNsight uses for determining the arrowhead type and the" +
+                      " color and thickness of the edges requires numerical weight values, your graph will display" +
+                      "  as an unweighted graph with black edges and pointed arrowheads. If you want to display" +
+                      " the network as a weighted graph, please modify your input file to include weight values" +
+                      " for all edges."
   },
 
   EDGE_DEFAULT_NOT_DIRECTED: {
@@ -24,11 +25,11 @@ var graphmlErrors = {
     return {
       errorCode: "GRAPHML_GENERAL_SYNTAX_ERROR",
       possibleCause: "There are a number of things that could've triggered this error, but the general gist is that" +
-      " there is something syntactically wrong with your file. The parcer we are using has associated your syntax error" +
-      " with this message: " + error + ".",
-      suggestedFix: "Please check the format of your file and make sure that it is in line with our Documentation page." +
-      " Some common errors to check for are missing start/end tags, missing quotation marks, and proper spelling of" +
-      " all attribute names."
+                     " there is something syntactically wrong with your file. The parcer we are using has associated" +
+                     " your syntax error with this message: " + error + ".",
+      suggestedFix:  "Please check the format of your file and make sure that it is in line with our Documentation page." +
+                     " Some common errors to check for are missing start/end tags, missing quotation marks, and proper" +
+                     " spelling of all attribute names."
     }
   }
 };
@@ -59,11 +60,16 @@ module.exports = function (graphml) {
     }
   });
 
-  if (network.errors.length > 0) { return semanticChecker(network); }
+  if (network.errors.length > 0) {
+    return semanticChecker(network);
+  }
 
   function pushRelevantError(err) {
     var parseError = readErrorFromErr(err);
     network.errors.push(graphmlErrors.GRAPHML_GENERAL_SYNTAX_ERROR(parseError));
+
+    // TODO Ask Dondi about how to do this in a more data-driven manner.
+
     // switch(parseError) {
     //   case "Invalid attribute name":
     //     network.errors.push(graphmlErrors.UNKNOWN_ERROR);

--- a/test/import-tests.js
+++ b/test/import-tests.js
@@ -192,6 +192,79 @@ var weightedTestGraphMlWithCycle = [
   '</graphml>'
 ].join("\n");
 
+var missingEndTagTestGraphMl = [
+  '<?xml version="1.0" encoding="UTF-8"?>',
+  '<graphml xmlns="http://graphml.graphdrawing.org/xmlns" ' +
+    'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+    'xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns ' +
+    'http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">',
+  '  <key id="edge-value-id" for="edge" attr.name="weight" attr.type="double"/>',
+  '  <graph edgedefault="directed"',
+  '    <node id="A"/>',
+  '    <node id="B"/>',
+  '    <node id="C"/>',
+  '    <node id="D"/>',
+  '    <edge source="B" target="A">',
+  '      <data key="edge-value-id">-0.75</data>',
+  '    </edge>',
+  '    <edge source="B" target="C">',
+  '      <data key="edge-value-id">0.25</data>',
+  '    </edge>',
+  '    <edge source="C" target="B">',
+  '      <data key="edge-value-id">0.5</data>',
+  '    </edge>',
+  '  </graph>',
+  '</graphml>'
+].join("\n");
+
+var missingGraphMlEndTagTestGraphMl = [
+  '<?xml version="1.0" encoding="UTF-8"?>',
+  '<graphml xmlns="http://graphml.graphdrawing.org/xmlns" ' +
+    'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+    'xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns ' +
+    'http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">',
+  '  <graph edgedefault="directed">',
+  '    <node id="A"/>',
+  '    <node id="B"/>',
+  '    <node id="C"/>',
+  '    <node id="D"/>',
+  '    <edge source="B" target="A">',
+  '      <data key="edge-value-id"></data>',
+  '    </edge>',
+  '    <edge source="B" target="C">',
+  '      <data key="edge-value-id"></data>',
+  '    </edge>',
+  '    <edge source="C" target="B">',
+  '      <data key="edge-value-id"></data>',
+  '    </edge>',
+  '  </graph>'
+].join("\n");
+
+var misspelledGraphTagTestGraphMl = [
+  '<?xml version="1.0" encoding="UTF-8"?>',
+  '<graphml xmlns="http://graphml.graphdrawing.org/xmlns" ' +
+    'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+    'xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns ' +
+    'http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">',
+  '  <key id="edge-value-id" for="edge" attr.name="weight" attr.type="double"/>',
+  '  <grah edgedefault="directed">',
+  '    <node id="A"/>',
+  '    <node id="B"/>',
+  '    <node id="C"/>',
+  '    <node id="D"/>',
+  '    <edge source="B" target="A">',
+  '      <data key="edge-value-id">-0.75</data>',
+  '    </edge>',
+  '    <edge source="B" target="C">',
+  '      <data key="edge-value-id">0.25</data>',
+  '    </edge>',
+  '    <edge source="C" target="B">',
+  '      <data key="edge-value-id">0.5</data>',
+  '    </edge>',
+  '  </graph>',
+  '</graphml>'
+].join("\n");
+
 describe("Import from GraphML", function () {
   it("should import unweighted networks from GraphML correctly", function () {
     expect(
@@ -215,6 +288,36 @@ describe("Import from GraphML", function () {
     expect(
       importController.graphMlToGrnsight(weightedTestGraphMlWithCycle)
     ).to.deep.equal(expectedWeightedNetworkWithCycle);
+  });
+
+  it("should issue an general graphML syntax error because there is a missing end tag", function () {
+    expect(
+      importController.graphMlToGrnsight(missingEndTagTestGraphMl).errors.length
+    ).to.equal(1);
+
+    expect(
+      importController.graphMlToGrnsight(missingEndTagTestGraphMl).errors[0].errorCode
+    ).to.equal("GRAPHML_GENERAL_SYNTAX_ERROR")
+  });
+
+  it("should issue an general graphML syntax error because </graphml> is missing", function () {
+    expect(
+      importController.graphMlToGrnsight(missingGraphMlEndTagTestGraphMl).errors.length
+    ).to.equal(1);
+
+    expect(
+      importController.graphMlToGrnsight(missingGraphMlEndTagTestGraphMl).errors[0].errorCode
+    ).to.equal("GRAPHML_GENERAL_SYNTAX_ERROR")
+  });
+
+  it("should issue an general graphML syntax error because the graph tag is misspelled", function () {
+    expect(
+      importController.graphMlToGrnsight(misspelledGraphTagTestGraphMl).errors.length
+    ).to.equal(1);
+
+    expect(
+      importController.graphMlToGrnsight(misspelledGraphTagTestGraphMl).errors[0].errorCode
+    ).to.equal("GRAPHML_GENERAL_SYNTAX_ERROR")
   });
 
   it("should issue a warning if edgedefault is not set to 'directed'", function () {


### PR DESCRIPTION
#363 As discussed on this issue, before this pull request, out servers crash whenever we input a graphML file with any sort of major syntactic error that is caught by the parser that we are using. I have created an error called the General GraphML Syntax Error and made it so that the very first thing that we check for on import is to make sure that there are no errors spewed out by the parser, and if so, then instantly return a network with a General GraphML Syntax Error. Let it be noted that not every syntactic error is caught by this. There is a full list of errors that we need to check for individually and some that are not caught by the parser at all. Find this list under #363 