### PR TITLE
Final Features for Release

### DIFF
--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -176,6 +176,16 @@ var drawGraph = function (nodes, links, positiveWeights, negativeWeights, sheetT
 
   d3.select(".center").on("click", center);
 
+  var getRangePoints = function (fractional, nonfractional) {
+      var minimumScaleAsReverse = 100 / (minimumScale * 100); // 1/4 scale is the opposite of 4x scale. We're getting the opposite.
+      var difference = maximumScale - minimumScaleAsReverse;
+      // if difference is positive, maxScale is bigger. if difference is negative, minScale is bigger.
+      // if it is 0, they are the same.
+      // Regardless, we want to use that difference.
+      // The proportion of the difference will give us the # extra points we'll need to normalize for..
+
+  }
+
   d3.select(".zoomSlider").on("input", function () {
     var newScale = this.value;
     zoom.scale(newScale);

--- a/web-client/public/stylesheets/grnsight.styl
+++ b/web-client/public/stylesheets/grnsight.styl
@@ -2,6 +2,7 @@
 
 body
   min-width: 1326px
+  overflow-x: hidden;
 
 p
   margin: 0

--- a/web-client/public/stylesheets/grnsight.styl
+++ b/web-client/public/stylesheets/grnsight.styl
@@ -2,7 +2,6 @@
 
 body
   min-width: 1326px
-  overflow-x: hidden;
 
 p
   margin: 0
@@ -51,6 +50,12 @@ p
 .zoomTable td
   height: 20px
   width: 120px
+
+.zoomCenter
+  position:absolute
+  width: 2px
+  background-color: #AAA
+  height: 20px
 
 .containerS
   width: 1104px

--- a/web-client/views/upload.jade
+++ b/web-client/views/upload.jade
@@ -209,10 +209,13 @@ html
           table(class='zoomTable')
             tr 
               td
-                input(class="zoomSlider" type="range" min="0" max="0" value="1" step="0.1")
-            tr
-              td
-                span(style="color:#AAA" id="zoomPercent") 100%
+                //- Initial setup for zoom center bar
+                //- div(class="zoomCenter")
+                input(class="zoomSlider" type="range" min="0" max="0" value="1" step="0.01")
+            //- Initial setup for showing zoom percentage
+            //- tr
+            //-   td
+            //-     span(style="color:#AAA" id="zoomPercent") 100%
 
     div(class='sidebar')
         //- Sliders should have the ID convention of -Name-Val and -Name-Input in order to work properly in the javascript
@@ -267,10 +270,11 @@ html
             <br>
             input(type='radio' id='weightsNeverSide' class='weightsNever' name='size')
             label(for='weightsNeverSide' style='font-weight:normal' class='sideLabel') Never Show Edge Weights
-          p(class='sideHeader') &nbsp; Set Normalization Factor:
-          input(type='text' class='normalization-form' id='normalization-min' placeholder='minimum' aria-describedby='basic-addon1')
-          br
-          input(type='text' class='normalization-form' id='normalization-max' placeholder='maximum' aria-describedby='basic-addon1')
+        //- Normalization controls hidden as per @kdahlquist's comment on issue #422
+        //-   p(class='sideHeader') &nbsp; Set Normalization Factor:
+        //-   input(type='text' class='normalization-form' id='normalization-min' placeholder='minimum' aria-describedby='basic-addon1')
+        //-   br
+        //-   input(type='text' class='normalization-form' id='normalization-max' placeholder='maximum' aria-describedby='basic-addon1')
 
     div(class='graph-statistics-container hidden')
       div(class='panel panel-default')

--- a/web-client/views/upload.jade
+++ b/web-client/views/upload.jade
@@ -210,9 +210,9 @@ html
             tr 
               td
                 input(class="zoomSlider" type="range" min="0" max="0" value="1" step="0.1")
-            //- tr
-            //-   td
-            //-     span(style="color:#AAA" id="zoomPercent") 100%
+            tr
+              td
+                span(style="color:#AAA" id="zoomPercent") 100%
 
     div(class='sidebar')
         //- Sliders should have the ID convention of -Name-Val and -Name-Input in order to work properly in the javascript


### PR DESCRIPTION
Fix #479 
Fix #461 - well, attempted. It's still got some buggy permutations where scrollbars appear when a graph is loaded while "fit to window" is selected, but I couldn't consistently find them and I got tired of fighting with it. They generally don't show up. 
#465 - Zoom slider now reflects accurate zoom level regardless of what's being used to zoom. It's still not the most pleasant thing to use, but it functions as intended. Clicking on it and then using the arrow keys making using it way more pleasant.
