### PR TITLE
Add quotes around eslint glob wildcards

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 assets/
+coverage/
 documents/
 test-files/
 web-client/public/lib/

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test": "mocha --reporter list",
     "start": "parallelshell --wait \"nodemon web-client/app.js\" \"nodemon server/app.js\"",
     "coverage": "istanbul cover _mocha",
-    "lint": "eslint **/*.js",
+    "lint": "eslint \"**/*.js\"",
     "coveralls": "npm run coverage -- --report lcovonly && cat ./coverage/lcov.info | coveralls"
   },
   "repository": {


### PR DESCRIPTION
Potential fix for #535 —This needs to be tested on Windows to make sure that it doesn’t cause a regression for that platform, since _eslint_ already works as needed there.

Reference: https://eslint.org/docs/user-guide/command-line-interface
