### PR TITLE
Beta consolidation first-full-cycle example

### DIFF
--- a/web-client/public/js/constants.js
+++ b/web-client/public/js/constants.js
@@ -1,0 +1,2 @@
+export const GREY_EDGES_DASHED_MENU = "#grey-edges-dashed-menu";
+export const GREY_EDGES_DASHED_SIDEBAR = "#dashedGrayLineButton";

--- a/web-client/public/js/grnsight.js
+++ b/web-client/public/js/grnsight.js
@@ -1,10 +1,17 @@
-const drawGraph = require("./graph").drawGraph;
-const sliderObject = require("./sliders").sliderObject;
-const sliderGroupController = require("./sliders").sliderGroupController;
-const container = require("./container").container;
-const displayStatistics = require("./graph-statistics").displayStatistics; // eslint-disable-line no-unused-vars
-const upload = require("./upload").upload;
-const nodeColoringController = require("./node-coloring").nodeColoringController;
+import { drawGraph } from "./graph";
+import { sliderObject } from "./sliders";
+import { sliderGroupController } from "./sliders";
+import { container } from "./container";
+import { displayStatistics } from "./graph-statistics"; // eslint-disable-line no-unused-vars
+import { upload } from "./upload";
+import { nodeColoringController } from "./node-coloring";
+
+import { grnState } from "./grnstate";
+import { updateApp } from "./update-app";
+import { setupHandlers } from "./setup-handlers";
+
+setupHandlers(grnState);
+updateApp(grnState);
 
 container();
 upload(sliderObject, sliderGroupController, drawGraph, nodeColoringController);

--- a/web-client/public/js/grnstate.js
+++ b/web-client/public/js/grnstate.js
@@ -1,0 +1,3 @@
+export const grnState = {
+    dashedLine: false
+}

--- a/web-client/public/js/grnstate.js
+++ b/web-client/public/js/grnstate.js
@@ -1,3 +1,3 @@
 export const grnState = {
     dashedLine: false
-}
+};

--- a/web-client/public/js/setup-handlers.js
+++ b/web-client/public/js/setup-handlers.js
@@ -1,9 +1,9 @@
-import { updateApp } from "./update-app"
+import { updateApp } from "./update-app";
 
 import {
     GREY_EDGES_DASHED_MENU,
     GREY_EDGES_DASHED_SIDEBAR
-} from "./constants"
+} from "./constants";
 
 export const setupHandlers = grnState => {
     $(GREY_EDGES_DASHED_SIDEBAR).change(() => {

--- a/web-client/public/js/setup-handlers.js
+++ b/web-client/public/js/setup-handlers.js
@@ -1,0 +1,18 @@
+import { updateApp } from "./update-app"
+
+import {
+    GREY_EDGES_DASHED_MENU,
+    GREY_EDGES_DASHED_SIDEBAR
+} from "./constants"
+
+export const setupHandlers = grnState => {
+    $(GREY_EDGES_DASHED_SIDEBAR).change(() => {
+        grnState.dashedLine = $(GREY_EDGES_DASHED_SIDEBAR).prop("checked");
+        updateApp(grnState);
+    });
+
+    $(GREY_EDGES_DASHED_MENU).click(() => {
+        grnState.dashedLine = !$(GREY_EDGES_DASHED_MENU).prop("checked");
+        updateApp(grnState);
+    });
+};

--- a/web-client/public/js/update-app.js
+++ b/web-client/public/js/update-app.js
@@ -1,0 +1,29 @@
+import { drawGraph } from "./graph";
+import { uploadState } from "./upload";
+
+import {
+  GREY_EDGES_DASHED_MENU,
+  GREY_EDGES_DASHED_SIDEBAR
+} from "./constants"
+
+// In this transitory state, updateApp might get called before things are completely set up, so for now
+// we define this wrapper function that guards against uninitialized values.
+const refreshApp = () => {
+    if (uploadState && uploadState.currentNetwork && uploadState.sliders && uploadState.nodeColoring) {
+        drawGraph(uploadState.currentNetwork, uploadState.sliders, uploadState.nodeColoring);
+    }
+}
+
+export const updateApp = grnState => {
+    if (grnState.dashedLine) {
+        $(GREY_EDGES_DASHED_MENU + " span").addClass("glyphicon-ok");
+        $(GREY_EDGES_DASHED_MENU).prop("checked", "checked");
+        $(GREY_EDGES_DASHED_SIDEBAR).prop("checked", "checked");
+        refreshApp();
+    } else if (!grnState.dashedLine) {
+        $(GREY_EDGES_DASHED_MENU + " span").removeClass("glyphicon-ok");
+        $(GREY_EDGES_DASHED_MENU).removeProp("checked");
+        $(GREY_EDGES_DASHED_SIDEBAR).removeProp("checked");
+        refreshApp();
+    }
+};

--- a/web-client/public/js/update-app.js
+++ b/web-client/public/js/update-app.js
@@ -4,7 +4,7 @@ import { uploadState } from "./upload";
 import {
   GREY_EDGES_DASHED_MENU,
   GREY_EDGES_DASHED_SIDEBAR
-} from "./constants"
+} from "./constants";
 
 // In this transitory state, updateApp might get called before things are completely set up, so for now
 // we define this wrapper function that guards against uninitialized values.
@@ -12,7 +12,7 @@ const refreshApp = () => {
     if (uploadState && uploadState.currentNetwork && uploadState.sliders && uploadState.nodeColoring) {
         drawGraph(uploadState.currentNetwork, uploadState.sliders, uploadState.nodeColoring);
     }
-}
+};
 
 export const updateApp = grnState => {
     if (grnState.dashedLine) {

--- a/web-client/public/js/upload.js
+++ b/web-client/public/js/upload.js
@@ -1,3 +1,12 @@
+// TODO Likely a temporary location, while things are being moved to their "true" homes.
+//      But placed here for now so that the true MVC cycle of grnState, updateApp, and the
+//      controller code installed by setupHandlers can access them.
+export const uploadState = {
+    currentNetwork: null,
+    sliders: null,
+    nodeColoring: null
+}
+
 export const upload = function (sliderObject, sliderGroupController, drawGraph, nodeColoringController) {
   // Slider Values
     var LINK_DIST_SLIDER_ID   = "#linkDistInput";
@@ -48,12 +57,14 @@ export const upload = function (sliderObject, sliderGroupController, drawGraph, 
     styleLabelTooltips();
 
     var nodeColoring = nodeColoringController;
+    uploadState.nodeColoring = nodeColoring;
     nodeColoring.configureNodeColoringHandlers();
     nodeColoring.initialize();
 
     var linkDistanceSlider = new sliderObject(LINK_DIST_SLIDER_ID, LINK_DIST_VALUE, LINK_DIST_DEFAULT, false);
     var chargeSlider = new sliderObject(CHARGE_SLIDER_ID, CHARGE_VALUE, CHARGE_DEFAULT, false);
     var sliders = new sliderGroupController([chargeSlider, linkDistanceSlider]);
+    uploadState.sliders = sliders;
     sliders.setSliderHandlers();
     sliders.updateValues();
     sliders.configureSliderControllers();
@@ -166,6 +177,7 @@ export const upload = function (sliderObject, sliderGroupController, drawGraph, 
         }
 
         currentNetwork = network;
+        uploadState.currentNetwork = network;
         console.log("Network: ", network); // Display the network in the console
         $("#graph-metadata").html(network.genes.length + " nodes<br>" + network.links.length + " edges");
 
@@ -396,32 +408,6 @@ export const upload = function (sliderObject, sliderGroupController, drawGraph, 
     $(GREY_EDGE_THRESHOLD_SLIDER_SIDEBAR).on("change", function () {
         var value = Math.round(($(GREY_EDGE_THRESHOLD_SLIDER_SIDEBAR).val() * 100));
         updateGrayEdgeValues(value);
-    });
-
-    // Dashed Gray Line Controller
-
-    var GREY_EDGES_DASHED_MENU = "#grey-edges-dashed-menu";
-    var GREY_EDGES_DASHED_SIDEBAR = "#dashedGrayLineButton";
-
-    var syncGreyEdgesAsDashedOptions = function (showAsDashed) {
-        if (showAsDashed) {
-            $(GREY_EDGES_DASHED_MENU + " span").addClass("glyphicon-ok");
-            $(GREY_EDGES_DASHED_MENU).prop("checked", "checked");
-            $(GREY_EDGES_DASHED_SIDEBAR).prop("checked", "checked");
-        } else {
-            $(GREY_EDGES_DASHED_MENU + " span").removeClass("glyphicon-ok");
-            $(GREY_EDGES_DASHED_MENU).removeProp("checked");
-            $(GREY_EDGES_DASHED_SIDEBAR).removeProp("checked");
-        }
-        drawGraph(currentNetwork, sliders, nodeColoring);
-    };
-
-    $(GREY_EDGES_DASHED_MENU).click(function () {
-        syncGreyEdgesAsDashedOptions(!$(GREY_EDGES_DASHED_MENU).prop("checked"));
-    });
-
-    $(GREY_EDGES_DASHED_SIDEBAR).on("change", function () {
-        syncGreyEdgesAsDashedOptions($(GREY_EDGES_DASHED_SIDEBAR).prop("checked"));
     });
 
     var annotateLinks = function (network) {

--- a/web-client/public/js/upload.js
+++ b/web-client/public/js/upload.js
@@ -5,7 +5,7 @@ export const uploadState = {
     currentNetwork: null,
     sliders: null,
     nodeColoring: null
-}
+};
 
 export const upload = function (sliderObject, sliderGroupController, drawGraph, nodeColoringController) {
   // Slider Values


### PR DESCRIPTION
OK @mihirsamdarshi and @johnllopez616, try taking this for a spin. I based this on the `dashedLine` work that @mihirsamdarshi had already started. All tests pass, and the functionality seems to be identical to the current posted beta.

Hope this helps clarify the MVC cycle discussed last Tuesday, and also shows how state can be shared across modules (temporarily, we hope) while things are in transition. Presumably, those values eventually find their way either in `grnState`, `updateApp`, or `setupHandlers`.

Please take a look at this before the meeting so that we can discuss any questions that you might have about this code.