### PR TITLE
Gene Page Changes Made 5/22/18

### DIFF
--- a/web-client/public/gene/api.js
+++ b/web-client/public/gene/api.js
@@ -9,8 +9,6 @@
             var XMLParser = function (data) {
                 return serializer.serializeToString(data).replace(/\<.*?\>\s?/g, "");
             };
-          //  var apiErrors = [];
-          //  var apiCount = 5;
 
             var getUniProtInfo = function (geneSymbol) {
                 return $.get({
@@ -92,7 +90,7 @@
 
             var getJasparInfo = function (geneSymbol) {
                 return $.get({
-                    url: "jaspar/api/v1/matrix/?tax_id=4932&format=json&search=" + geneSymbol,
+                    url: "../jaspar/api/v1/matrix/?tax_id=4932&format=json&search=" + geneSymbol,
                     dataType: "json",
                     beforeSend: function (xhr) {
                         xhr.setRequestHeader("content-type", "application/json");
@@ -100,7 +98,7 @@
                 }).then(function (data) {
                     return (data.count === 0 ? {} :
                         $.get({
-                            url: "jaspar/api/v1/matrix/" + data.results[0].matrix_id,
+                            url: "../jaspar/api/v1/matrix/" + data.results[0].matrix_id,
                             dataType: "json",
                             beforeSend: function (xhr) {
                                 xhr.setRequestHeader("content-type", "application/json");
@@ -171,7 +169,7 @@
             };
 
             var defaultValues = {
-                jaspar: defaultJaspar,
+                jaspar:  defaultJaspar,
                 ncbi: defaultNCBI,
                 ensembl: defaultEnsembl,
                 uniprot: defaultUniprot,
@@ -280,6 +278,7 @@
            }).catch(function () {
                return defaultValues;
            }).fail(function () {
+              //check properties of default values to ensure that they are all "Not found"
                var errorString1 = "No gene information was retrieved for " + symbol + ".";
 
                var errorString2 = "This could have happened because either"

--- a/web-client/public/gene/api.js
+++ b/web-client/public/gene/api.js
@@ -100,7 +100,7 @@
                 }).then(function (data) {
                     return (data.count === 0 ? {} :
                         $.get({
-                            url: "/jaspar/api/v1/matrix/" + data.results[0].matrix_id,
+                            url: "http://jaspar.genereg.net/api/v1/matrix/" + data.results[0].matrix_id,
                             dataType: "json",
                             beforeSend: function (xhr) {
                                 xhr.setRequestHeader("content-type", "application/json");
@@ -109,6 +109,150 @@
                     );
                 });
             };
+
+
+            var defaultJaspar = {
+                jasparID: "Not found",
+                class: "Not found",
+                family: "Not found",
+                sequenceLogo: "Not found",
+                frequencyMatrix: "Not found"
+            };
+
+            var defaultNCBI  = {
+                ncbiID: "Not found",
+                locusTag: "Not found",
+                alsoKnownAs: "Not found",
+                chromosomeSequence: "Not found",
+                genomicSequence: "Not found"
+            };
+
+            var defaultUniprot = {
+                uniprotID: "Not found",
+                proteinSequence: "Not found",
+                proteinType: "Not found",
+                species: "Not found"
+            };
+
+            var defaultEnsembl = {
+                ensemblID:  "Not found",
+                description: "Not found",
+                dnaSequence:  "Not found",
+                geneLocation:  "Not found"
+            };
+
+            var defaultYeastmine = {
+
+                sgdID: "Not found",
+                standardName: "Not found",
+                systematicName: "Not found",
+                regulators: "Not found",
+                targets: "Not found",
+                totalInteractions: "Not found",
+                affinityCaptureMS: "Not found",
+                affinityCaptureRNA: "Not found",
+                affinityCaptureWestern: "Not found",
+                biochemicalActivity: "Not found",
+                colocalization: "Not found",
+                reconstitutedComplex: "Not found",
+                twoHybrid: "Not found",
+                dosageRescue: "Not found",
+                negativeGenetic: "Not found",
+                phenotypicEnhancement: "Not found",
+                phenotypicSuppression: "Not found",
+                syntheticGrowthDefect: "Not found",
+                syntheticHaploinsufficiency: "Not found",
+                syntheticLethality: "Not found",
+                syntheticRescue: "Not found",
+                geneOntologySummary: "Not found",
+                molecularFunction: "Not found",
+                biologicalProcess: "Not found",
+                cellularComponent: "Not found"
+            };
+
+            var defaultValues = {
+                jaspar: defaultJaspar,
+                ncbi: defaultNCBI,
+                ensembl: defaultEnsembl,
+                uniprot: defaultUniprot,
+                sgd: defaultYeastmine
+            };
+
+            var parseUniprot = function (data) {
+                return {
+                    uniprotID: XMLParser(data.getElementsByTagName("name")[0]),
+                    proteinSequence: XMLParser(data.getElementsByTagName("sequence")[0]),
+                    proteinType: XMLParser(data.getElementsByTagName("protein")[0].childNodes[1].childNodes[1]),
+                    species: XMLParser(data.getElementsByTagName("organism")[0].childNodes[1]),
+                };
+            };
+
+            var parseNCBI = function (data) {
+                var tagArray = serializer.serializeToString(
+                    data.getElementsByTagName("OtherAliases")[0]).split(",");
+                return {
+                    ncbiID: data.getElementsByTagName("DocumentSummary")[0].getAttribute("uid"),
+                    locusTag: tagArray[0].replace(/\<.*?\>\s?/g, ""),
+                    alsoKnownAs: tagArray.slice(1).join().replace(/\<.*?\>\s?/g, ""),
+                    chromosomeSequence: XMLParser(data.getElementsByTagName("ChrAccVer")[0]),
+                    genomicSequence: XMLParser(data.getElementsByTagName("ChrLoc")[0]) + "; "
+                    + XMLParser(data.getElementsByTagName("ChrAccVer")[0]) + " ("
+                    + XMLParser(data.getElementsByTagName("ChrStart")[0])
+                     + ".." + XMLParser(data.getElementsByTagName("ChrStop")[0]) + ")",
+                };
+            };
+
+            var parseYeastmine = function (data) {
+                return {
+                    sgdID: data.primaryIdentifier,
+                    standardName: data.symbol,
+                    systematicName: data.secondaryIdentifier,
+                    regulators: "N/A", // Information unavailable via regular API
+                    targets: "N/A", // Information unavailable via regular API
+                    totalInteractions: "N/A", // Information unavailable via regular API
+                    affinityCaptureMS: "N/A", // Information unavailable via regular API
+                    affinityCaptureRNA: "N/A", // Information unavailable via regular API
+                    affinityCaptureWestern: "N/A", // Information unavailable via regular API
+                    biochemicalActivity: "N/A", // Information unavailable via regular API
+                    colocalization: "N/A", // Information unavailable via regular API
+                    reconstitutedComplex: "N/A", // Information unavailable via regular API
+                    twoHybrid: "N/A", // Information unavailable via regular API
+                    dosageRescue: "N/A", // Information unavailable via regular API
+                    negativeGenetic: "N/A", // Information unavailable via regular API
+                    phenotypicEnhancement: "N/A", // Information unavailable via regular API
+                    phenotypicSuppression: "N/A", // Information unavailable via regular API
+                    syntheticGrowthDefect: "N/A", // Information unavailable via regular API
+                    syntheticHaploinsufficiency: "N/A", // Information unavailable via regular API
+                    syntheticLethality: "N/A", // Information unavailable via regular API
+                    syntheticRescue: "N/A", // Information unavailable via regular API
+                    geneOntologySummary: data.functionSummary,
+                    molecularFunction: "N/A", // Information unavailable via regular API
+                    biologicalProcess: "N/A", // Information unavailable via regular API
+                    cellularComponent: "N/A", // Information unavailable via regular API
+                };
+            };
+
+            var parseEnsembl = function (data) {
+                return {
+                    ensemblID: data.id,
+                    description: data.description,
+                    dnaSequence: "N/A", // Information unavailable via regular API
+                    geneLocation: "N/A", // Information unavailable via regular API
+                };
+            };
+
+            var parseJaspar = function (data) {
+
+                return data ? {
+                    jasparID : data.matrix_id,
+                    class: data.class,
+                    family: data.family,
+                    sequenceLogo: data.sequence_logo,
+                    frequencyMatrix: data.pfm,
+                } : {};
+            };
+
+
 
             // change if any preprocessing needs to be done on the data before being given to the application
             var filterData = function (uniprotInfo, ncbiInfo, yeastmineInfo, ensemblInfo, jasparInfo) {
@@ -194,32 +338,53 @@
                 };
             };
 
+            $.when(
+                getUniProtInfo(symbol)
+              ).then(function (info) {
+                  defaultValues.uniprot = parseUniprot(info);
+              });
+
+            $.when(
+              getYeastMineInfo(symbol)
+            ).then(function (info) {
+                defaultValues.sgd = parseYeastmine(info[0]);
+            });
+
+            $.when(
+              getEnsemblInfo(symbol)
+            ).then(function (info) {
+                defaultValues.ensembl = parseEnsembl(info);
+            });
+
+
+            $.when(
+            getJasparInfo(symbol)
+          ).then(function (info) {
+              defaultValues.jaspar = parseJaspar(info);
+          });
 
 
             return $.when(
-                getUniProtInfo(symbol),
-                getNCBIInfo(symbol),
-                getYeastMineInfo(symbol),
-                getEnsemblInfo(symbol),
-                getJasparInfo(symbol)
-            ).then(function (uniprotInfo, ncbiInfo, yeastmineInfo, ensemblInfo, jasparInfo) {
- /*                console.log(
-                    "uniprot", uniprotInfo[0],
-                    "ncbi", ncbiInfo[0],
-                    "yeastmine", yeastmineInfo[0],
-                    "ensembl", ensemblInfo[0],
-                    "jaspar", jasparInfo[0]); */
-                return filterData(uniprotInfo[0], ncbiInfo[0], yeastmineInfo[0], ensemblInfo[0], jasparInfo[0]);
+             getNCBIInfo(symbol)
+            ).then(function (info) {
+                defaultValues.ncbi = parseNCBI(info);
+                console.log(defaultValues);
+                return defaultValues;
             }).fail(function () {
-                var errorString = "Gene page functionality is currently down for maintenance.";
-              /*
-                var errorString = "The gene you have selected is not found in any of our databases.";
-                if (apiErrors.length < apiCount) {
-                    errorString = "We could not extract information from the following databases: " +
-                    apiErrors.join(", ");
-                } */
-                $("#error").text(errorString);
+                var errorString1 = "No gene information was retrieved for " + symbol + ".";
+
+                var errorString2 = "This could have happened because either"
+                + " GRNsight could not access the gene information from one of the source databases"
+                + " or because no information exists for the gene in the source databases.";
+
+                var errorString3 = "You can check back later to see if gene information"
+                + " can be retrieved or submit an issue to https://github.com/dondi/GRNsight.";
+
+                $("#error1").text(errorString1);
+                $("#error2").text(errorString2);
+                $("#error3").text(errorString3);
                 $("#errorModal").modal("show");
+
             });
         }
     };

--- a/web-client/public/gene/api.js
+++ b/web-client/public/gene/api.js
@@ -252,140 +252,48 @@
                 } : {};
             };
 
-
-
-            // change if any preprocessing needs to be done on the data before being given to the application
-            var filterData = function (uniprotInfo, ncbiInfo, yeastmineInfo, ensemblInfo, jasparInfo) {
-                var parseUniprot = function (data) {
-                    return {
-                        uniprotID: XMLParser(data.getElementsByTagName("name")[0]),
-                        proteinSequence: XMLParser(data.getElementsByTagName("sequence")[0]),
-                        proteinType: XMLParser(data.getElementsByTagName("protein")[0].childNodes[1].childNodes[1]),
-                        species: XMLParser(data.getElementsByTagName("organism")[0].childNodes[1]),
-                    };
-                };
-
-                var parseNCBI = function (data) {
-                    var tagArray = serializer.serializeToString(
-                        data.getElementsByTagName("OtherAliases")[0]).split(",");
-                    return {
-                        ncbiID: data.getElementsByTagName("DocumentSummary")[0].getAttribute("uid"),
-                        locusTag: tagArray[0].replace(/\<.*?\>\s?/g, ""),
-                        alsoKnownAs: tagArray.slice(1).join().replace(/\<.*?\>\s?/g, ""),
-                        chromosomeSequence: XMLParser(data.getElementsByTagName("ChrAccVer")[0]),
-                        genomicSequence: XMLParser(data.getElementsByTagName("ChrLoc")[0]) + "; "
-                        + XMLParser(data.getElementsByTagName("ChrAccVer")[0]) + " ("
-                        + XMLParser(data.getElementsByTagName("ChrStart")[0])
-                         + ".." + XMLParser(data.getElementsByTagName("ChrStop")[0]) + ")",
-                    };
-                };
-
-                var parseYeastmine = function (data) {
-                    return {
-                        sgdID: data.primaryIdentifier,
-                        standardName: data.symbol,
-                        systematicName: data.secondaryIdentifier,
-                        regulators: "N/A", // Information unavailable via regular API
-                        targets: "N/A", // Information unavailable via regular API
-                        totalInteractions: "N/A", // Information unavailable via regular API
-                        affinityCaptureMS: "N/A", // Information unavailable via regular API
-                        affinityCaptureRNA: "N/A", // Information unavailable via regular API
-                        affinityCaptureWestern: "N/A", // Information unavailable via regular API
-                        biochemicalActivity: "N/A", // Information unavailable via regular API
-                        colocalization: "N/A", // Information unavailable via regular API
-                        reconstitutedComplex: "N/A", // Information unavailable via regular API
-                        twoHybrid: "N/A", // Information unavailable via regular API
-                        dosageRescue: "N/A", // Information unavailable via regular API
-                        negativeGenetic: "N/A", // Information unavailable via regular API
-                        phenotypicEnhancement: "N/A", // Information unavailable via regular API
-                        phenotypicSuppression: "N/A", // Information unavailable via regular API
-                        syntheticGrowthDefect: "N/A", // Information unavailable via regular API
-                        syntheticHaploinsufficiency: "N/A", // Information unavailable via regular API
-                        syntheticLethality: "N/A", // Information unavailable via regular API
-                        syntheticRescue: "N/A", // Information unavailable via regular API
-                        geneOntologySummary: data.functionSummary,
-                        molecularFunction: "N/A", // Information unavailable via regular API
-                        biologicalProcess: "N/A", // Information unavailable via regular API
-                        cellularComponent: "N/A", // Information unavailable via regular API
-                    };
-                };
-
-                var parseEnsembl = function (data) {
-                    return {
-                        ensemblID: data.id,
-                        description: data.description,
-                        dnaSequence: "N/A", // Information unavailable via regular API
-                        geneLocation: "N/A", // Information unavailable via regular API
-                    };
-                };
-
-                var parseJaspar = function (data) {
-
-                    return data ? {
-                        jasparID : data.matrix_id,
-                        class: data.class,
-                        family: data.family,
-                        sequenceLogo: data.sequence_logo,
-                        frequencyMatrix: data.pfm,
-                    } : {};
-                };
-                return {
-                    jaspar: parseJaspar(jasparInfo),
-                    ncbi: parseNCBI(ncbiInfo),
-                    ensembl: parseEnsembl(ensemblInfo),
-                    uniprot: parseUniprot(uniprotInfo),
-                    sgd: parseYeastmine(yeastmineInfo),
-                };
-            };
-
-            $.when(
-                getUniProtInfo(symbol)
-              ).then(function (info) {
-                  defaultValues.uniprot = parseUniprot(info);
-              });
-
-            $.when(
-              getYeastMineInfo(symbol)
-            ).then(function (info) {
-                defaultValues.sgd = parseYeastmine(info[0]);
-            });
-
-            $.when(
-              getEnsemblInfo(symbol)
-            ).then(function (info) {
-                defaultValues.ensembl = parseEnsembl(info);
-            });
-
-
-            $.when(
-            getJasparInfo(symbol)
-          ).then(function (info) {
-              defaultValues.jaspar = parseJaspar(info);
-          });
-
-
             return $.when(
              getNCBIInfo(symbol)
-            ).then(function (info) {
-                defaultValues.ncbi = parseNCBI(info);
-                console.log(defaultValues);
-                return defaultValues;
-            }).fail(function () {
-                var errorString1 = "No gene information was retrieved for " + symbol + ".";
+           ).then(function (info1) {
+               defaultValues.ncbi = parseNCBI(info1);
+               return getUniProtInfo(symbol);
+           }).catch(function () {
+               return getUniProtInfo(symbol);
+           }).then(function (info2) {
+               defaultValues.uniprot = parseUniprot(info2);
+               return getYeastMineInfo(symbol);
+           }).catch(function () {
+               return getYeastMineInfo(symbol);
+           }).then(function (info3) {
+               defaultValues.sgd = parseYeastmine(info3[0]);
+               return getEnsemblInfo(symbol);
+           }).catch(function () {
+               return getEnsemblInfo(symbol);
+           }).then(function (info4) {
+               defaultValues.ensembl = parseEnsembl(info4);
+               return getJasparInfo(symbol);
+           }).catch(function () {
+               return getJasparInfo(symbol);
+           }).then(function (info5) {
+               defaultValues.jaspar = parseJaspar(info5);
+               return defaultValues;
+           }).catch(function () {
+               return defaultValues;
+           }).fail(function () {
+               var errorString1 = "No gene information was retrieved for " + symbol + ".";
 
-                var errorString2 = "This could have happened because either"
+               var errorString2 = "This could have happened because either"
                 + " GRNsight could not access the gene information from one of the source databases"
                 + " or because no information exists for the gene in the source databases.";
 
-                var errorString3 = "You can check back later to see if gene information"
+               var errorString3 = "You can check back later to see if gene information"
                 + " can be retrieved or submit an issue to https://github.com/dondi/GRNsight.";
 
-                $("#error1").text(errorString1);
-                $("#error2").text(errorString2);
-                $("#error3").text(errorString3);
-                $("#errorModal").modal("show");
-
-            });
+               $("#error1").text(errorString1);
+               $("#error2").text(errorString2);
+               $("#error3").text(errorString3);
+               $("#errorModal").modal("show");
+           });
         }
     };
 })($);

--- a/web-client/public/gene/api.js
+++ b/web-client/public/gene/api.js
@@ -92,7 +92,7 @@
 
             var getJasparInfo = function (geneSymbol) {
                 return $.get({
-                    url: "http://jaspar.genereg.net/api/v1/matrix/?tax_id=4932&format=json&search=" + geneSymbol,
+                    url: "jaspar/api/v1/matrix/?tax_id=4932&format=json&search=" + geneSymbol,
                     dataType: "json",
                     beforeSend: function (xhr) {
                         xhr.setRequestHeader("content-type", "application/json");
@@ -100,7 +100,7 @@
                 }).then(function (data) {
                     return (data.count === 0 ? {} :
                         $.get({
-                            url: "http://jaspar.genereg.net/api/v1/matrix/" + data.results[0].matrix_id,
+                            url: "jaspar/api/v1/matrix/" + data.results[0].matrix_id,
                             dataType: "json",
                             beforeSend: function (xhr) {
                                 xhr.setRequestHeader("content-type", "application/json");

--- a/web-client/public/gene/api.js
+++ b/web-client/public/gene/api.js
@@ -278,7 +278,7 @@
            }).catch(function () {
                return defaultValues;
            }).fail(function () {
-              //check properties of default values to ensure that they are all "Not found"
+              // check properties of default values to ensure that they are all "Not found"
                var errorString1 = "No gene information was retrieved for " + symbol + ".";
 
                var errorString2 = "This could have happened because either"

--- a/web-client/public/gene/info.css
+++ b/web-client/public/gene/info.css
@@ -83,7 +83,7 @@ iframe {
 }
 
 #mainPage {
-  margin-top: -450px;
+  margin-top: -480px;
   z-index: 1;
   margin-left: -25px;
 }

--- a/web-client/public/gene/info.html
+++ b/web-client/public/gene/info.html
@@ -17,7 +17,9 @@
           </button>
         </div>
         <div class="modal-body">
-          <p id="error"></p>
+          <p id="error1"></p>
+          <p id="error2"></p>
+          <p id="error3"></p>
         </div>
         <div class="modal-footer">
           <input type="button" class="btn btn-default" data-dismiss="modal" value="Close">

--- a/web-client/public/gene/info.js
+++ b/web-client/public/gene/info.js
@@ -19,10 +19,15 @@
     // https://stackoverflow.com/questions/8648892/convert-url-parameters-to-a-javascript-object
 
     var api = window.api;
+
     api.getGeneInformation(obj.symbol).done(function (gene) {
+
+
 
         var sgdHrefTemplate = "https://www.yeastgenome.org/locus/";
         var sgdId = gene.sgd.sgdID;
+        console.log(gene);
+        console.log(gene.sgd.systematicName);
         $(".sgd-link").text(sgdId).attr({ href: sgdHrefTemplate + sgdId });
 
         var ncbiHrefTemplate = "https://www.ncbi.nlm.nih.gov/gene/";

--- a/web-client/public/gene/info.js
+++ b/web-client/public/gene/info.js
@@ -22,12 +22,8 @@
 
     api.getGeneInformation(obj.symbol).done(function (gene) {
 
-
-
         var sgdHrefTemplate = "https://www.yeastgenome.org/locus/";
         var sgdId = gene.sgd.sgdID;
-        console.log(gene);
-        console.log(gene.sgd.systematicName);
         $(".sgd-link").text(sgdId).attr({ href: sgdHrefTemplate + sgdId });
 
         var ncbiHrefTemplate = "https://www.ncbi.nlm.nih.gov/gene/";


### PR DESCRIPTION
Addresses part of #620 and #621.

Regarding #620, I reduced the margin between the GRNsight logo header and the content of the gene page.

Regarding #621, I created a series of default values that read "no info". I eliminated the `filterData()` function and simplified the `getGeneInformationFunction()` to return a chain of promises that catch any errors when an AJAX call cannot be made from the `get[Database]Info()` functions, while still allowing the functions to modify the data of the default values. At the very end, the changed default values are passed into `info.js`.

Unfortunately, the issue regarding the JASPAR CORS error still persists without the use of a browser plugin. Additionally, with the plugin, the JASPAR function will not return due to the following error regarding loading the matrix:

`Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://localhost:5001' is therefore not allowed access.`

This might require us having to contact the developer, according to @mihirsamdarshi's suggestion.