### PR TITLE
Gene Page Changes Made 5/23/2018

### DIFF
--- a/web-client/public/gene/api.js
+++ b/web-client/public/gene/api.js
@@ -250,6 +250,7 @@
                 } : {};
             };
 
+
             return $.when(
              getNCBIInfo(symbol)
            ).then(function (info1) {
@@ -278,20 +279,28 @@
            }).catch(function () {
                return defaultValues;
            }).fail(function () {
-              // check properties of default values to ensure that they are all "Not found"
-               var errorString1 = "No gene information was retrieved for " + symbol + ".";
 
-               var errorString2 = "This could have happened because either"
-                + " GRNsight could not access the gene information from one of the source databases"
-                + " or because no information exists for the gene in the source databases.";
+               if (
+                 defaultValues.ncbi === defaultNCBI &&
+                 defaultValues.uniprot === defaultUniprot &&
+                 defaultValues.sgd === defaultYeastmine &&
+                 defaultValues.ensembl === defaultEnsembl &&
+                 defaultValues.jaspar === defaultJaspar
+               ) {
+                   var errorString1 = "No gene information was retrieved for " + symbol + ".";
 
-               var errorString3 = "You can check back later to see if gene information"
-                + " can be retrieved or submit an issue to https://github.com/dondi/GRNsight.";
+                   var errorString2 = "This could have happened because either"
+                    + " GRNsight could not access the gene information from one of the source databases"
+                    + " or because no information exists for the gene in the source databases.";
 
-               $("#error1").text(errorString1);
-               $("#error2").text(errorString2);
-               $("#error3").text(errorString3);
-               $("#errorModal").modal("show");
+                   var errorString3 = "You can check back later to see if gene information"
+                    + " can be retrieved or submit an issue to https://github.com/dondi/GRNsight.";
+
+                   $("#error1").text(errorString1);
+                   $("#error2").text(errorString2);
+                   $("#error3").text(errorString3);
+                   $("#errorModal").modal("show");
+               }
            });
         }
     };

--- a/web-client/public/gene/info.css
+++ b/web-client/public/gene/info.css
@@ -5,7 +5,7 @@ body {
 iframe {
   border:none;
   width: 100%;
-  height: 100%;
+  z-index: 1;
 }
 
 .btn {
@@ -90,18 +90,11 @@ iframe {
 }
 
 #iframeMenu {
-  height: 600px;
-  z-index: 0;
+  height: 100%;
+  position: absolute;
 }
 
 #mainPage {
-  margin-top: 200px;
-  z-index: 1;
-  margin-left: -25px;
-}
-
-@media only screen and (max-width: 600px) {
-    body {
-        background-color: lightblue;
-    }
+  margin-top: -25px;
+  z-index: 0;
 }

--- a/web-client/public/gene/info.css
+++ b/web-client/public/gene/info.css
@@ -5,6 +5,7 @@ body {
 iframe {
   border:none;
   width: 100%;
+  height: 100%;
 }
 
 .btn {
@@ -49,14 +50,20 @@ iframe {
   font-weight: 700;
 }
 
+
 .jumbotron {
   background-color: white;
-  padding-bottom:0px !important;
+  padding-bottom: 0px !important;
 }
 
 .sequenceLogo {
-  width: 50%;
+  width: 100%;
 }
+
+.frequencyMatrix {
+  width: 100%;
+}
+
 
 .green {
   color: #16693f;
@@ -88,7 +95,13 @@ iframe {
 }
 
 #mainPage {
-  margin-top: -480px;
+  margin-top: 200px;
   z-index: 1;
   margin-left: -25px;
+}
+
+@media only screen and (max-width: 600px) {
+    body {
+        background-color: lightblue;
+    }
 }

--- a/web-client/public/gene/info.css
+++ b/web-client/public/gene/info.css
@@ -2,11 +2,6 @@ body {
   font-family: sans-serif;
 }
 
-code {
-  font-family: Courier;
-  color:black;
-}
-
 iframe {
   border:none;
   width: 100%;
@@ -44,13 +39,23 @@ iframe {
   color: black;
 }
 
+.codeSequence {
+  font-family: Courier;
+  color:black;
+}
+
 .database-link {
+  color:  #16693f;
   font-weight: 700;
 }
 
 .jumbotron {
   background-color: white;
   padding-bottom:0px !important;
+}
+
+.sequenceLogo {
+  width: 50%;
 }
 
 .green {

--- a/web-client/public/gene/info.html
+++ b/web-client/public/gene/info.html
@@ -7,6 +7,8 @@
 </head>
 
 <body>
+
+  <!-- The following code is for the error modal -->
   <div id="errorModal" class="modal fade" tab-index='-1' role='dialog' aria-labelledby='mySmallModalLabel' aria-hidden='true'>
     <div class="modal-dialog">
       <div class="modal-content">
@@ -27,14 +29,16 @@
       </div>
     </div>
   </div>
+  <!-- End error modal -->
 
 
   <div class="container-fluid">
+    <iframe src="http://dondi.github.io/GRNsight/onlyheader.html" scrolling="no"></iframe>
     <div class="row">
       <div class="col-2">
         <iframe id="iframeMenu" src="http://dondi.github.io/GRNsight/onlysidebar.html" scrolling="no"></iframe>
       </div>
-      <div class="col-10" id="mainPage">
+      <div class="col-10"  id="mainPage">
         <div class="row" id="pageHead">
           <div class="jumbotron">
             <div>
@@ -101,7 +105,7 @@
         </div>
         <div class="row">
           <div class="col-12">
-            <div id="mainContent" id="accordion">
+            <div id="accordion">
               <div class="card">
                 <div class="card-header" role="tab" id="dnaSequenceHeading">
                   <h5 class="mb-0">

--- a/web-client/public/gene/info.html
+++ b/web-client/public/gene/info.html
@@ -75,15 +75,15 @@
             <div class="card-block">
               <dl class="row">
                 <dt class="col-sm-3">SGD ID: </dt>
-                <dd class="col-sm-9"> <a class="lead sgd-link green database-link" href="https://www.yeastgenome.org/locus/S000001855" data-toggle="tooltip" data-placement="top" title="Saccharomyces Genome Database"></a>&nbsp;&nbsp;</dd>
-                <dt class="col-sm-3">NCBI ID: </dt>
-                <dd class="col-sm-9"><a class="lead ncbi-link purple database-link" href="https://www.ncbi.nlm.nih.gov/gene/850504" data-toggle="tooltip" data-placement="top" title="National Center for Biotechnology Information"></a>&nbsp;&nbsp;</dd>
+                <dd class="col-sm-9"> <a class="lead sgd-link database-link" href="https://www.yeastgenome.org/locus/S000001855" data-toggle="tooltip" data-placement="top" title="Saccharomyces Genome Database"></a>&nbsp;&nbsp;</dd>
+                <dt class="col-sm-3">NCBI Gene ID: </dt>
+                <dd class="col-sm-9"><a class="lead ncbi-link database-link" href="https://www.ncbi.nlm.nih.gov/gene/850504" data-toggle="tooltip" data-placement="top" title="National Center for Biotechnology Information"></a>&nbsp;&nbsp;</dd>
                 <dt class="col-sm-3">Ensembl ID:</dt>
-                <dd class="col-sm-9"><a class="lead ensembl-link brown database-link" href="https://www.ensembl.org/Saccharomyces_cerevisiae/Gene/Summary?db=core;g=YFL039C;r=VI:53260-54696;t=YFL039C" data-toggle="tooltip" data-placement="top" title="Ensembl"></a>&nbsp;&nbsp;</dd>
+                <dd class="col-sm-9"><a class="lead ensembl-link database-link" href="https://www.ensembl.org/Saccharomyces_cerevisiae/Gene/Summary?db=core;g=YFL039C;r=VI:53260-54696;t=YFL039C" data-toggle="tooltip" data-placement="top" title="Ensembl"></a>&nbsp;&nbsp;</dd>
                 <dt class="col-sm-3">Uniprot ID: </dt>
-                <dd class="col-sm-9"><a class="lead uniprot-link turquoise database-link" href="http://www.uniprot.org/uniprot/P60010" data-toggle="tooltip" data-placement="top" title="UniProt"></a></dd>
+                <dd class="col-sm-9"><a class="lead uniprot-link database-link" href="http://www.uniprot.org/uniprot/P60010" data-toggle="tooltip" data-placement="top" title="UniProt"></a></dd>
                 <dt class="col-sm-3">JASPAR ID: </dt>
-                <dd class="col-sm-9"><a class="lead jaspar-link violet database-link" href="http://jaspar.genereg.net/matrix/MA0080.1/" data-toggle="tooltip" data-placement="top" title="Jaspar"></a></dd>
+                <dd class="col-sm-9"><a class="lead jaspar-link database-link" href="http://jaspar.genereg.net/matrix/MA0080.1/" data-toggle="tooltip" data-placement="top" title="Jaspar"></a></dd>
                 <dt class="col-sm-3">Description: </dt>
                 <dd class="ensemblDescription col-sm-9 ensemblSource"></dd>
                 <dt class="col-sm-3">Species: </dt>
@@ -113,10 +113,7 @@
                 </div>
                 <div id="dnaSequence" class="collapse">
                   <div class="card-block">
-                    <p class="ensemblSource">
-                      <code class="dnaSequenceCode"></code>
-                      <!-- DNA sequence goes there, -->
-                    </p>
+                    <p class="ensemblSource dnaSequenceCode codeSequence"></p>
                   </div>
                 </div>
               </div>
@@ -130,13 +127,12 @@
                 </div>
                 <div id="proteinInfo" class="collapse">
                   <div class="card-block">
-                    <h2>Protein Type: </h2>
-                    <p class="proteinType uniprotSource"></p>
-                    <h2>Protein Sequence: </h2>
-                    <p class="uniprotSource">
-                      <code class="proteinSequence"></code>
-                      <!-- it goes here from UniProt between code tags -->
-                    </p>
+                    <dl class="row">
+                      <dt class="col-sm-3">Protein Type:</dt>
+                      <dd class="col-sm-9 proteinType uniprotSource"> </dd>
+                      <dt class="col-sm-3">Protein Source:</dt>
+                      <dd class="col-sm-9 uniprotSource proteinSequence codeSequence"></dd>
+                    </dl>
                   </div>
                 </div>
               </div>
@@ -150,32 +146,34 @@
                 </div>
                 <div id="regulation" class="collapse">
                   <div class="card-block">
-                    <dl class="row">
-                      <dd class="col-sm-3"> Regulators: </dd>
-                      <dt class="regulators col-sm-9 sgdSource"></dt>
-                      <dd class="col-sm-3"> Targets: </dd>
-                      <dt class="targets col-sm-9 sgdSource"></dt>
-                      <dd class="col-sm-3 jasparSource"> Frequency Matrix: </dd>
-                      <img class="sequenceLogo" src="">
-                      <dd class="col-sm-3 jasparSource"> Sequence Info: </dd>
-                      <table class="frequencyMatrix table table-dark table-striped">
-                        <thead>
-                          <tr class="frequencyOfA">
-                            <th>A:</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          <tr class="frequencyOfC">
-                            <th>C:</th>
-                          </tr>
-                          <tr class="frequencyOfG">
-                            <th>G:</th>
-                          </tr>
-                          <tr class="frequencyOfT">
-                            <th>T:</th>
-                          </tr>
-                        </tbody>
-                      </table>
+                    <dl class="row dl-horizontal">
+                      <dt class="col-sm-3"> Regulators: </dt>
+                      <dd class="regulators col-sm-9 sgdSource"></dd>
+                      <dt class="col-sm-3"> Targets: </dt>
+                      <dd class="targets col-sm-9 sgdSource"></dd>
+                      <dt class="col-sm-3"> Frequency Matrix: </dt>
+                      <dd class="col-sm-9"><img class="sequenceLogo" src=""></dd>
+                      <dt class="col-sm-3"> Sequence Info: </dt>
+                      <dd class="col-sm-9">
+                        <table class="frequencyMatrix table table-dark table-striped">
+                          <thead>
+                            <tr class="frequencyOfA">
+                              <th>A:</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr class="frequencyOfC">
+                              <th>C:</th>
+                            </tr>
+                            <tr class="frequencyOfG">
+                              <th>G:</th>
+                            </tr>
+                            <tr class="frequencyOfT">
+                              <th>T:</th>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </dd>
                     </dl>
                   </div>
                 </div>
@@ -272,21 +270,20 @@
                 </div>
                 <div id="sources" class="collapse">
                   <div class="card-block">
-                    <dl class="row justify-content-center">
-                      <a class="col-6 col-md-4 sgd-link green" id="sgdSource"></a>
-
+                    <dl class="row">
+                      <a class="col-6 col-md-4 sgd-link database-link" id="sgdSource"></a>
                     </dl>
-                    <dl class="row justify-content-center">
-                      <a class="col-6 col-md-4 uniprot-link turquoise" id="uniprotSource"></a>
+                    <dl class="row">
+                      <a class="col-6 col-md-4 uniprot-link database-link" id="uniprotSource"></a>
                     </dl>
-                    <dl class="row justify-content-center">
-                      <a class="col-6 col-md-4 ensembl-link brown" id="ensemblSource"></a>
+                    <dl class="row">
+                      <a class="col-6 col-md-4 ensembl-link database-link" id="ensemblSource"></a>
                     </dl>
-                    <dl class="row justify-content-center">
-                      <a class="col-6 col-md-4 ncbi-link purple" id="ncbiSource"></a>
+                    <dl class="row">
+                      <a class="col-6 col-md-4 ncbi-link database-link" id="ncbiSource"></a>
                     </dl>
-                    <dl class="row justify-content-center">
-                      <a class="col-6 col-md-4 jaspar-link violet" id="jasparSource"></a>
+                    <dl class="row">
+                      <a class="col-6 col-md-4 jaspar-link database-link" id="jasparSource"></a>
                     </dl>
                   </div>
                 </div>

--- a/web-client/public/gene/info.html
+++ b/web-client/public/gene/info.html
@@ -31,9 +31,8 @@
 
   <div class="container-fluid">
     <div class="row">
-      <iframe id="iframeMenu" src="http://dondi.github.io/GRNsight/onlysidebar.html" scrolling="no"></iframe>
       <div class="col-2">
-        <!--iframe will go here" -->
+        <iframe id="iframeMenu" src="http://dondi.github.io/GRNsight/onlysidebar.html" scrolling="no"></iframe>
       </div>
       <div class="col-10" id="mainPage">
         <div class="row" id="pageHead">

--- a/web-client/public/gene/info.js
+++ b/web-client/public/gene/info.js
@@ -5,16 +5,6 @@
           return key === "" ? value : decodeURIComponent(value);
       }) : {};
 
-// The following code is for the accordion link:
-    $("button, .sourceLink").click(function (event) {
-        alert("hey");
-        event.preventDefault();
-        var anchorName = $(this).attr("data-target") + "Heading";
-        $("html, body").animate({scrollTop: $(anchorName).offset().top});
-    });
-
-
-
     document.title = "GRNsight - " + obj.symbol;
     $("#gene-name").text(obj.symbol);
     // This is cite used to find the parsing:
@@ -77,11 +67,9 @@
       // Regulation Information
         var sgdRequlators = gene.sgd.regulators;
         $(".regulators").text(sgdRequlators).attr({ href: sgdHrefTemplate + sgdRequlators });
-        $("<a class='sgd-link'><sup>1</sup></a>").appendTo(".regulators");
 
         var sgdTargets = gene.sgd.targets;
         $(".targets").text(sgdTargets).attr({ href: sgdHrefTemplate + sgdTargets });
-        $("<a class='sgd-link'><sup>1</sup></a>").appendTo(".targets");
 
       // Interaction: Physical Reaction
 
@@ -151,20 +139,6 @@
         var sgdCellularComponent = gene.sgd.cellularComponent;
         $(".cellularComponent").text(sgdCellularComponent).attr({ href: sgdHrefTemplate + sgdCellularComponent });
 
-        $("#sgdSource").text("1. Saccharomyces Genome Database");
-        $("<a class=\"sourceLink\" data-target=\"#sources\" href=\"sources\"><sup>[1]</sup></a>").appendTo(".sgdSource");
-        $("#uniprotSource").text("2. UniProt");
-        $("<sup>[2]</sup>").appendTo(".uniprotSource");
-        $("#ensemblSource").text("3. Ensembl");
-        $("<sup>[3]</sup>").appendTo(".ensemblSource");
-        $("#ncbiSource").text("4. NCBI Database");
-        $("<sup>[4]</sup>").appendTo(".ncbiSource");
-        $("#jasparSource").text("5. Jaspar Database");
-        $("<sup>[5[]</sup>").appendTo(".jasparSource");
-
-
-
-
         // Fequency Matrix and Sequence Logo
         var sequenceLogo = gene.jaspar.sequenceLogo;
         $(".sequenceLogo").attr({ src : sequenceLogo });
@@ -190,6 +164,30 @@
             t += "<td>" + frequencyMatrix.T[h] + "</td>";
         }
         $(".frequencyOfT").append($(t));
+
+        $("#sgdSource").text("1. Saccharomyces Genome Database");
+        $("#uniprotSource").text("2. UniProt");
+        $("#ensemblSource").text("3. Ensembl");
+        $("#ncbiSource").text("4. NCBI Database");
+        $("#jasparSource").text("5. Jaspar Database");
+
+        $("<a class=\"sourceLink\"> <sup>[1]</sup></a>").appendTo(".sgdSource");
+        $("<a class=\"sourceLink\"><sup>[2]</sup></a>").appendTo(".uniprotSource");
+        $("<a class=\"sourceLink\"><sup>[3]</sup></a>").appendTo(".ensemblSource");
+        $("<a class=\"sourceLink\"><sup>[4]</sup></a>").appendTo(".ncbiSource");
+        $("<a class=\"sourceLink\"><sup>[5]</sup></a>").appendTo(".jasparSource");
+
+        $( ".sourceLink" ).attr({
+            "data-toggle": "collapse",
+            "data-target": "#sources",
+            "href": "#sources"
+        });
+
+        $(".sourceLink, button").click(function (event) {
+            event.preventDefault();
+            var anchorName = $(this).attr("data-target") + "Heading";
+            $("html, body").animate({scrollTop: $(anchorName).offset().top});
+        });
+
     });
 })();
-// All api calls and page design elements have been linked

--- a/web-client/public/gene/info.js
+++ b/web-client/public/gene/info.js
@@ -6,11 +6,13 @@
       }) : {};
 
 // The following code is for the accordion link:
-    $("button").click(function (event) {
+    $("button, .sourceLink").click(function (event) {
+        alert("hey");
         event.preventDefault();
         var anchorName = $(this).attr("data-target") + "Heading";
         $("html, body").animate({scrollTop: $(anchorName).offset().top});
     });
+
 
 
     document.title = "GRNsight - " + obj.symbol;
@@ -150,15 +152,15 @@
         $(".cellularComponent").text(sgdCellularComponent).attr({ href: sgdHrefTemplate + sgdCellularComponent });
 
         $("#sgdSource").text("1. Saccharomyces Genome Database");
-        $("<sup>1</sup>").appendTo(".sgdSource");
+        $("<a class=\"sourceLink\" data-target=\"#sources\" href=\"sources\"><sup>[1]</sup></a>").appendTo(".sgdSource");
         $("#uniprotSource").text("2. UniProt");
-        $("<sup>2</sup>").appendTo(".uniprotSource");
+        $("<sup>[2]</sup>").appendTo(".uniprotSource");
         $("#ensemblSource").text("3. Ensembl");
-        $("<sup>3</sup>").appendTo(".ensemblSource");
+        $("<sup>[3]</sup>").appendTo(".ensemblSource");
         $("#ncbiSource").text("4. NCBI Database");
-        $("<sup>4</sup>").appendTo(".ncbiSource");
+        $("<sup>[4]</sup>").appendTo(".ncbiSource");
         $("#jasparSource").text("5. Jaspar Database");
-        $("<sup>5</sup>").appendTo(".jasparSource");
+        $("<sup>[5[]</sup>").appendTo(".jasparSource");
 
 
 


### PR DESCRIPTION
Addresses the following issues in #620 

- [x] Let's make the hyperlinks on the page to be the main green GRNsight color, instead of multi-colored.  The buttons and section headers look nice with the different colors, but I think to be clear, the rest of the hyperlinks should just be the main GRNsight green color.  This affects both the General and Sources sections.
- [x] Let's use the Wikipedia convention of putting the source citations in square brackets like this <sup>[1]</sup>.
- [x] Let's make the source citations in the square brackets link to the sources section (like a Wikipedia page does).
- [x] In the Sources section, please move the list of citations over to the left-hand side, with the same margin as the other sections above it.
- [x] Let's regularize the font size and bolding for all the sections.  For example, in the regulation section, the field names are not bolded, in the protein section the font is really large.  Whatever the size they are in the general section is good (and bolded).
- [x] The protein sequence is not displaying correctly.  It has a leading space that should be removed and there are line breaks in the sequence that are not being respected when the window is maximized.
- [x] In the general section, it is "NCBI Gene ID" not just "NCBI ID".  NCBI has a lot of different databases and the one we are calling is the "Gene" Database.
- [x] The Jaspar sequence logo image and matrix need to be moved a little to the right.  The matrix is actually overlapping the edge of the section on the left-hand side.
- [x] Can the Jaspar sequence logo image be made a little smaller?