### PR TITLE
Removed Z-Indexes from style

### DIFF
--- a/web-client/public/gene/info.css
+++ b/web-client/public/gene/info.css
@@ -44,13 +44,11 @@ sup {
   position: absolute;
   min-height: 450px;
   min-width: 160px;
-  z-index: -1;
 }
 
 #iframeFooter {
   width: 100%;
 	display: block;
-  z-index: 0;
 }
 
 #mainContent {


### PR DESCRIPTION
Addresses Issue #704 . By removing the z-indexes from the iFrames, I have resolved the issue created from PR #702. I have verified the solution works on Chrome, IE, and Firefox, while avoiding any overlapping style issues.