### PR TITLE
Edited based on comments and fixed some bugs

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -12,7 +12,7 @@ module.exports = {
             name: "GRNsight"
         },
         databaseHost: "localhost",  // This will most likely stay as localhost due to tunneling.
-        databaseName: "grnsight_database",
+        databaseName: "postgres",
         databaseDialect: "postgres"
     },
 
@@ -26,7 +26,7 @@ module.exports = {
             name: "GRNsight"
         },
         databaseHost: "<database host for production database>",
-        databaseName: "grnsight_database",
+        databaseName: "postgres",
         databaseDialect: "postgres"
     },
 
@@ -40,7 +40,7 @@ module.exports = {
             name: "GRNsight"
         },
         databaseHost: "<database host for beta database>",
-        databaseName: "grnsight_database",
+        databaseName: "postgres",
         databaseDialect: "postgres"
     }
 };

--- a/server/controllers/database-controller.js
+++ b/server/controllers/database-controller.js
@@ -73,7 +73,7 @@ let buildGenesQuery = function (geneString) {
     let geneList = geneString.split(",");
     geneList.forEach(x => genes += ("standardname=\'" + x + "\' OR "));
     return genes.substring(0, genes.length - 4);
-}
+};
 
 let buildQuery = function (dataset, timepoints, genes) {
     return timepoints ?
@@ -81,18 +81,8 @@ let buildQuery = function (dataset, timepoints, genes) {
     (${buildTimepointsQuery(timepoints)}) ORDER BY sortindex AND
     (${buildGenesQuery(genes)}) ORDER BY sortindex;`
     : `SELECT * FROM expressiondata WHERE dataset='${dataset}'
-    AND (${buildGenesQuery(genes)}) ORDER BY sortindex;`
+    AND (${buildGenesQuery(genes)}) ORDER BY sortindex;`;
 
-};
-
-let listUniqueGenes = function (arrayOfObjects) {
-    let uniqueGenes = [];
-    arrayOfObjects.forEach(function (x) {
-        if (!uniqueGenes.includes(x.standardname)) {
-            uniqueGenes.push(x.standardname);
-        }
-    });
-    return uniqueGenes;
 };
 
 let listGeneData = function (gene, totalOutput) {

--- a/server/controllers/database-controller.js
+++ b/server/controllers/database-controller.js
@@ -97,14 +97,12 @@ let listGeneData = function (gene, totalOutput) {
 
 let convertToJSON = function (totalOutput, dataset, timePoints, allGenes) {
     let JSONOutput = {
-        [dataset]: {
-            timePoints,
-            data: {
-                id: timePoints
-            }
+        timePoints,
+        data: {
+            id: timePoints
         }
     };
-    allGenes.forEach(x => JSONOutput[dataset].data[x.toString()] = listGeneData(x, totalOutput));
+    allGenes.forEach(x => JSONOutput.data[x.toString()] = listGeneData(x, totalOutput));
     return JSONOutput;
 };
 

--- a/server/controllers/database-controller.js
+++ b/server/controllers/database-controller.js
@@ -19,7 +19,7 @@ var sequelize = new Sequelize(
 
 const timepointsSources = [
     {
-        key: "Barreto_2018_wt",
+        key: "Barreto_2012_wt",
         value: [10, 10, 20, 20, 20, 20, 40, 40, 40, 40, 60, 60, 60, 60, 120, 120, 120, 120]
     },
 

--- a/server/controllers/expression-sheet-parser.js
+++ b/server/controllers/expression-sheet-parser.js
@@ -32,7 +32,8 @@ const warningsList = {
         return {
             warningCode: "MISSING_EXPRESSION_SHEET",
             errorDescription: "_log2_expression or _log2_optimized_expression worksheet was not detected. \
-            The network graph will display without node coloring."
+            The network graph will display without node coloring. If you wish for the network to be colored, \
+            you can upload your own expression data, or use options from our Expression Database."
         };
     },
     extraneousDataWarning: function () {

--- a/server/controllers/spreadsheet-controller.js
+++ b/server/controllers/spreadsheet-controller.js
@@ -194,7 +194,8 @@ var warningsList = {
     missingExpressionSheetWarning: {
         warningCode: "MISSING_EXPRESSION_SHEET",
         errorDescription: "_log2_expression or _log2_optimized_expression worksheet was not detected. \
-        The network graph will display without node coloring."
+        The network graph will display without node coloring. If you wish for the network to be colored, \
+        you can upload your own expression data, or use options from our Expression Database."
     },
 };
 

--- a/test/expression-data-import-tests.js
+++ b/test/expression-data-import-tests.js
@@ -5,7 +5,9 @@ var test = require("./test");
 describe("expression-data-import-tests", function () {
 
     describe("MISSING_EXPRESSION_SHEET", function () {
-        it.skip("_log2_expression or _log2_optimized_expression worksheet was not detected. The network graph will display without node coloring.", function () {
+        it.skip("_log2_expression or _log2_optimized_expression worksheet was not detected. ",
+        "The network graph will display without node coloring. If you wish for the network to be colored, ",
+        "you can upload your own expression data, or use options from our Expression Database.", function () {
             test.missingExpressionWarning("test-files/expression-data-test-sheets/expression_sheet_not_existing.xlsx", 1);
         });
     });

--- a/web-client/public/js/constants.js
+++ b/web-client/public/js/constants.js
@@ -124,6 +124,7 @@ export const AVG_REPLICATE_VALS_BOTTOM_MENU             = "#averageDataBottomMen
 export const NODE_COLORING_TOGGLE_MENU                  = "#node-coloring-toggle-menu";
 export const NODE_COLORING_TOGGLE_CLASS                 = ".nodeColoringToggle";
 export const LOG_FOLD_CHANGE_MAX_VALUE_CLASS            = ".logFoldChangeMaxValue";
+export const LOG_FOLD_CHANGE_MAX_VALUE_HEADER           = "#logFoldChangeMaxValue";
 export const LOG_FOLD_CHANGE_MAX_VALUE_SIDEBAR_INPUT    = "#log-fold-change-max-value-sidebar";
 export const LOG_FOLD_CHANGE_MAX_VALUE_SIDEBAR_BUTTON   = "#log-fold-change-button";
 export const LOG_FOLD_CHANGE_MAX_VALUE_MENU             = "#log-fold-change-max-value-menu";

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1121,12 +1121,18 @@ export var drawGraph = function (network) {
 
     updaters.renderNodeColoring = function () {
         if (grnState.nodeColoring.nodeColoringEnabled) {
+            // console.log("NODE COLORING BEING RENDERED");
             colorNodes("top", grnState.nodeColoring.topDataset, grnState.nodeColoring.averageTopDataset,
                 grnState.nodeColoring.logFoldChangeMaxValue);
             colorNodes("bottom", grnState.nodeColoring.bottomDataset, grnState.nodeColoring.averageBottomDataset,
                 grnState.nodeColoring.logFoldChangeMaxValue);
             renderNodeLabels();
             renderNodeColoringLegend(grnState.nodeColoring.logFoldChangeMaxValue);
+            // console.log("top: " + JSON.stringify(grnState.nodeColoring.topDataset));
+            // console.log("bottom: " + JSON.stringify(colorNodes("bottom", grnState.nodeColoring.bottomDataset, grnState.nodeColoring.averageBottomDataset,
+            // grnState.nodeColoring.logFoldChangeMaxValue)));
+            // console.log("node labels: " + renderNodeLabels());
+            // console.log("legend: " + renderNodeColoringLegend(grnState.nodeColoring.logFoldChangeMaxValue));
         }
     };
 

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1121,18 +1121,12 @@ export var drawGraph = function (network) {
 
     updaters.renderNodeColoring = function () {
         if (grnState.nodeColoring.nodeColoringEnabled) {
-            // console.log("NODE COLORING BEING RENDERED");
             colorNodes("top", grnState.nodeColoring.topDataset, grnState.nodeColoring.averageTopDataset,
                 grnState.nodeColoring.logFoldChangeMaxValue);
             colorNodes("bottom", grnState.nodeColoring.bottomDataset, grnState.nodeColoring.averageBottomDataset,
                 grnState.nodeColoring.logFoldChangeMaxValue);
             renderNodeLabels();
             renderNodeColoringLegend(grnState.nodeColoring.logFoldChangeMaxValue);
-            // console.log("top: " + JSON.stringify(grnState.nodeColoring.topDataset));
-            // console.log("bottom: " + JSON.stringify(colorNodes("bottom", grnState.nodeColoring.bottomDataset, grnState.nodeColoring.averageBottomDataset,
-            // grnState.nodeColoring.logFoldChangeMaxValue)));
-            // console.log("node labels: " + renderNodeLabels());
-            // console.log("legend: " + renderNodeColoringLegend(grnState.nodeColoring.logFoldChangeMaxValue));
         }
     };
 

--- a/web-client/public/js/update-app.js
+++ b/web-client/public/js/update-app.js
@@ -656,7 +656,7 @@ export const updateApp = grnState => {
     
             };
     
-            responseData("expression", "././controllers/database-controller.js").then(function (response) {
+            responseData("expression").then(function (response) {
                 grnState.network.expression = response;
                 grnState.nodeColoring.nodeColoringEnabled = true;
                 $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).removeClass("hidden");

--- a/web-client/public/js/update-app.js
+++ b/web-client/public/js/update-app.js
@@ -82,6 +82,7 @@ import {
   SPECIES_DISPLAY,
   EXPRESSION_DB_LOADER,
   EXPRESSION_DB_LOADER_TEXT,
+  NODE_COLORING_TOGGLE_CLASS,
   SPECIES_BUTTON_CRESS,
   SPECIES_BUTTON_FLY,
   SPECIES_BUTTON_HUMAN,
@@ -447,7 +448,7 @@ const resetDatasetDropdownMenus = (network) => {
     }
 
     // Add expression database options
-    grnState.nodeColoring.nodeColoringOptions.push({value: "Barreto_2018_wt"});
+    grnState.nodeColoring.nodeColoringOptions.push({value: "Barreto_2012_wt"});
     grnState.nodeColoring.nodeColoringOptions.push({value: "Dahlquist_2018_dcin5"});
     grnState.nodeColoring.nodeColoringOptions.push({value: "Dahlquist_2018_dgln3"});
     grnState.nodeColoring.nodeColoringOptions.push({value: "Dahlquist_2018_dhap4"});
@@ -602,8 +603,17 @@ export const updateApp = grnState => {
         updatetoGridLayout();
     }
 
-
-// Node Coloring
+    // Node Coloring
+    // if (grnState.network !== null) {
+    //     if (!hasExpressionData(grnState.network.expression)) {
+    //         $(NODE_COLORING_TOGGLE_CLASS).click();
+    //     }
+    // }
+    // if (grnState.network !== null && !hasExpressionData(grnState.network.expression)) {
+    //     $(NODE_COLORING_SIDEBAR_BODY).removeClass("hidden");
+    //     $(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked", false);
+    //     // grnState.nodeColoring.nodeColoringEnabled = false;
+    // }
     if (grnState.network !== null && grnState.nodeColoring.nodeColoringEnabled
     && hasExpressionData(grnState.network.expression)) {
         grnState.nodeColoring.showMenu = true;
@@ -615,25 +625,27 @@ export const updateApp = grnState => {
         $(NODE_COLORING_SIDEBAR_BODY).removeClass("hidden");
         updaters.renderNodeColoring();
     } else if (grnState.network !== null && !hasExpressionData(grnState.network.expression)
-    && grnState.nodeColoring.nodeColoringEnabled) {
-        $(`${NODE_COLORING_TOGGLE_MENU} span`).removeClass("glyphicon-ok");
-        $(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked", true);
-        $(NODE_COLORING_SIDEBAR_BODY).addClass("hidden");
+    && grnState.nodeColoring.nodeColoringEnabled /*&& $(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked")*/) {
+        // $(`${NODE_COLORING_TOGGLE_MENU} span`).removeClass("glyphicon-ok");
+        // $(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked", false);
+        // $(NODE_COLORING_SIDEBAR_BODY).addClass("hidden");
         updaters.removeNodeColoring();
 
         console.log("Expression data loading from database.");
+
         grnState.nodeColoring.showMenu = true;
-        $(AVG_REPLICATE_VALS_TOP_SIDEBAR).prop("checked", true);
-        $(AVG_REPLICATE_VALS_BOTTOM_SIDEBAR).prop("checked", true);
-        $(`${NODE_COLORING_TOGGLE_MENU} span`).addClass("glyphicon-ok");
-        $(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked", true);
-        $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).val(DEFAULT_MAX_LOG_FOLD_CHANGE);
-        $(NODE_COLORING_SIDEBAR_BODY).removeClass("hidden");
+        // $(AVG_REPLICATE_VALS_TOP_SIDEBAR).prop("checked", true);
+        // $(AVG_REPLICATE_VALS_BOTTOM_SIDEBAR).prop("checked", true);
+        // $(`${NODE_COLORING_TOGGLE_MENU} span`).addClass("glyphicon-ok");
+        // $(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked", false);
+        // $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).val(DEFAULT_MAX_LOG_FOLD_CHANGE);
+        // $(NODE_COLORING_SIDEBAR_BODY).removeClass("hidden");
+        // $(NODE_COLORING_TOGGLE_CLASS).click();
         resetDatasetDropdownMenus(grnState.network);
         grnState.nodeColoring.topDataset = grnState.nodeColoring.topDataset ?
-        grnState.nodeColoring.topDataset : "Barreto_2018_wt";
+        grnState.nodeColoring.topDataset : "Barreto_2012_wt";
         grnState.nodeColoring.bottomDataset = grnState.nodeColoring.bottomDataset ?
-        grnState.nodeColoring.bottomDataset : "Barreto_2018_wt";
+        grnState.nodeColoring.bottomDataset : "Barreto_2012_wt";
         let queryURL = buildURL({dataset: grnState.nodeColoring.topDataset});
         const responseData = (name, formData) => {
             return new Promise(function (resolve) {

--- a/web-client/public/js/update-app.js
+++ b/web-client/public/js/update-app.js
@@ -228,8 +228,14 @@ const buildGeneQuery = function () {
 
 const buildURL = function (selection) {
     return selection.timepoints ?
-    "expressiondb?dataset=" + selection.dataset + "&genes=" + buildGeneQuery() + "&timepoints=" + buildTimepointsString(selection)
+    "expressiondb?dataset=" + selection.dataset + "&genes=" +
+    buildGeneQuery() + "&timepoints=" + buildTimepointsString(selection)
     : "expressiondb?dataset=" + selection.dataset + "&genes=" + buildGeneQuery();
+};
+
+const startLoadingIcon = function () {
+    $(EXPRESSION_DB_LOADER).css("display", "block");
+    $(EXPRESSION_DB_LOADER_TEXT).css("display", "block");
 };
 
 const responseData = (formData, queryURL) => {
@@ -252,11 +258,6 @@ const responseData = (formData, queryURL) => {
             }).error(console.log("Error in accessing expression database. Result may just be loading."));
     });
 
-};
-
-const startLoadingIcon = function () {
-    $(EXPRESSION_DB_LOADER).css("display", "block");
-    $(EXPRESSION_DB_LOADER_TEXT).css("display", "block");
 };
 
 const stopLoadingIcon = function () {
@@ -457,8 +458,8 @@ const clearDropdownMenus = () => {
 };
 
 const expressionDBDatasets = ["Barreto_2012_wt", "Dahlquist_2018_dcin5",
-"Dahlquist_2018_dgln3", "Dahlquist_2018_dhap4", "Dahlquist_2018_dzap1",
-"Dahlquist_2018_wt", "Kitagawa_2002_wt", "Thorsen_2007_wt"];
+    "Dahlquist_2018_dgln3", "Dahlquist_2018_dhap4", "Dahlquist_2018_dzap1",
+    "Dahlquist_2018_wt", "Kitagawa_2002_wt", "Thorsen_2007_wt"];
 
 const resetDatasetDropdownMenus = (network) => {
     clearDropdownMenus();
@@ -644,18 +645,20 @@ export const updateApp = grnState => {
         $(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked", true);
         $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).val(DEFAULT_MAX_LOG_FOLD_CHANGE);
         $(NODE_COLORING_SIDEBAR_BODY).removeClass("hidden");
-        if (expressionDBDatasets.includes(grnState.nodeColoring.topDataset) && grnState.network.expression[grnState.nodeColoring.topDataset] === undefined) {
+        if (expressionDBDatasets.includes(grnState.nodeColoring.topDataset) &&
+        grnState.network.expression[grnState.nodeColoring.topDataset] === undefined) {
             if ($(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked")) {
                 let queryURLTop = buildURL({dataset: grnState.nodeColoring.topDataset});
-        
+
                 responseData("", queryURLTop).then(function (response) {
                     grnState.network.expression[grnState.nodeColoring.topDataset] = response;
                     grnState.nodeColoring.nodeColoringEnabled = true;
                     $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).removeClass("hidden");
                     $(LOG_FOLD_CHANGE_MAX_VALUE_SIDEBAR_BUTTON).removeClass("hidden");
                     $(LOG_FOLD_CHANGE_MAX_VALUE_HEADER).removeClass("hidden");
-    
-                    if (grnState.nodeColoring.bottomDataSameAsTop || !expressionDBDatasets.includes(grnState.nodeColoring.bottomDataset)) {
+
+                    if (grnState.nodeColoring.bottomDataSameAsTop ||
+                    !expressionDBDatasets.includes(grnState.nodeColoring.bottomDataset)) {
                         stopLoadingIcon();
                         updaters.renderNodeColoring();
                     }
@@ -665,7 +668,9 @@ export const updateApp = grnState => {
                     console.log(error.message);
                 });
             }
-        } else if (expressionDBDatasets.includes(grnState.nodeColoring.bottomDataset) && !grnState.nodeColoring.bottomDataSameAsTop && grnState.network.expression[grnState.nodeColoring.bottomDataset] === undefined) {
+        } else if (expressionDBDatasets.includes(grnState.nodeColoring.bottomDataset) &&
+        !grnState.nodeColoring.bottomDataSameAsTop &&
+        grnState.network.expression[grnState.nodeColoring.bottomDataset] === undefined) {
             if (!grnState.nodeColoring.bottomDataSameAsTop) {
                 let queryURLBottom = buildURL({dataset: grnState.nodeColoring.bottomDataset});
                 responseData("", queryURLBottom).then(function (response) {
@@ -689,7 +694,8 @@ export const updateApp = grnState => {
     } else if (grnState.network !== null && !hasExpressionData(grnState.network.expression)
     && grnState.nodeColoring.nodeColoringEnabled) {
         if ((grnState.network.expression[grnState.nodeColoring.topDataset] === undefined) ||
-        (!grnState.nodeColoring.bottomDataSameAsTop && grnState.network.expression[grnState.nodeColoring.bottomDataset] === undefined)) {
+        (!grnState.nodeColoring.bottomDataSameAsTop &&
+        grnState.network.expression[grnState.nodeColoring.bottomDataset] === undefined)) {
             updaters.removeNodeColoring();
         }
         grnState.nodeColoring.showMenu = true;
@@ -704,14 +710,14 @@ export const updateApp = grnState => {
         if ($(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked")) {
             if (grnState.network.expression[grnState.nodeColoring.topDataset] === undefined) {
                 let queryURLTop = buildURL({dataset: grnState.nodeColoring.topDataset});
-    
+
                 responseData("", queryURLTop).then(function (response) {
                     grnState.network.expression[grnState.nodeColoring.topDataset] = response;
                     grnState.nodeColoring.nodeColoringEnabled = true;
                     $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).removeClass("hidden");
                     $(LOG_FOLD_CHANGE_MAX_VALUE_SIDEBAR_BUTTON).removeClass("hidden");
                     $(LOG_FOLD_CHANGE_MAX_VALUE_HEADER).removeClass("hidden");
-    
+
                     if (grnState.nodeColoring.bottomDataSameAsTop) {
                         stopLoadingIcon();
                         updaters.renderNodeColoring();
@@ -721,7 +727,8 @@ export const updateApp = grnState => {
                     console.log(error.name);
                     console.log(error.message);
                 });
-            } else if (!grnState.nodeColoring.bottomDataSameAsTop && grnState.network.expression[grnState.nodeColoring.bottomDataset] === undefined) {
+            } else if (!grnState.nodeColoring.bottomDataSameAsTop &&
+            grnState.network.expression[grnState.nodeColoring.bottomDataset] === undefined) {
                 let queryURLBottom = buildURL({dataset: grnState.nodeColoring.bottomDataset});
                 responseData("", queryURLBottom).then(function (response) {
                     grnState.network.expression[grnState.nodeColoring.bottomDataset] = response;

--- a/web-client/public/js/update-app.js
+++ b/web-client/public/js/update-app.js
@@ -68,6 +68,8 @@ import {
   BOTTOM_DATASET_SELECTION_SIDEBAR,
   BOTTOM_DATASET_SELECTION_MENU,
   LOG_FOLD_CHANGE_MAX_VALUE_CLASS,
+  LOG_FOLD_CHANGE_MAX_VALUE_SIDEBAR_BUTTON,
+  LOG_FOLD_CHANGE_MAX_VALUE_HEADER,
   MAX_NUM_CHARACTERS_DROPDOWN,
   ENDS_IN_EXPRESSION_REGEXP,
   ZOOM_CONTROL,
@@ -82,7 +84,6 @@ import {
   SPECIES_DISPLAY,
   EXPRESSION_DB_LOADER,
   EXPRESSION_DB_LOADER_TEXT,
-  NODE_COLORING_TOGGLE_CLASS,
   SPECIES_BUTTON_CRESS,
   SPECIES_BUTTON_FLY,
   SPECIES_BUTTON_HUMAN,
@@ -627,6 +628,9 @@ export const updateApp = grnState => {
         grnState.nodeColoring.topDataset : "Barreto_2012_wt";
         grnState.nodeColoring.bottomDataset = grnState.nodeColoring.bottomDataset ?
         grnState.nodeColoring.bottomDataset : "Barreto_2012_wt";
+        $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).addClass("hidden");
+        $(LOG_FOLD_CHANGE_MAX_VALUE_SIDEBAR_BUTTON).addClass("hidden");
+        $(LOG_FOLD_CHANGE_MAX_VALUE_HEADER).addClass("hidden");
         if ($(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked")) {
             let queryURL = buildURL({dataset: grnState.nodeColoring.topDataset});
             const responseData = (name, formData) => {
@@ -655,6 +659,11 @@ export const updateApp = grnState => {
             responseData("expression", "././controllers/database-controller.js").then(function (response) {
                 grnState.network.expression = response;
                 grnState.nodeColoring.nodeColoringEnabled = true;
+                $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).removeClass("hidden");
+                $(LOG_FOLD_CHANGE_MAX_VALUE_SIDEBAR_BUTTON).removeClass("hidden");
+                $(LOG_FOLD_CHANGE_MAX_VALUE_HEADER).removeClass("hidden");
+
+                
                 // updateApp(grnState);
                 updaters.renderNodeColoring();
             }).catch(function (error) {

--- a/web-client/public/js/upload.js
+++ b/web-client/public/js/upload.js
@@ -97,4 +97,7 @@ export const upload = function () {
     $("#exportAsWeightedSif").click(performExport("export-to-sif", "sif", "weighted"));
     $("#exportAsUnweightedGraphMl").click(performExport("export-to-graphml", "graphml", "unweighted"));
     $("#exportAsWeightedGraphMl").click(performExport("export-to-graphml", "graphml", "weighted"));
+    $("#exportAsUnweightedExcel").click(performExport("export-to-excel", "xlsx", "unweighted"));
+    $("#exportAsWeightedExcel").click(performExport("export-to-excel", "xlsx", "weighted"));
+
 };

--- a/web-client/public/stylesheets/grnsight.styl
+++ b/web-client/public/stylesheets/grnsight.styl
@@ -295,13 +295,6 @@ text.weight.visible
     margin-bottom: 4px
     margin-top: 6px
 
-.centered-sideHeader
-    font-weight: normal
-    font-size: 13px
-    margin-bottom: 4px
-    margin-top: 6px
-    text-align: center
-
 .nodeColoringSidebarBody
   margin-top: 6px
 

--- a/web-client/views/upload.jade
+++ b/web-client/views/upload.jade
@@ -366,7 +366,7 @@ html
                 input(id='nodeColoringToggleSidebar' class='nodeColoringToggle' type='checkbox' checked)
                 label(for='nodeColoringToggleSidebar' class='sideLabel') Enable Node Coloring
               div(class="nodeColoringSidebarBody")
-                p(class='centered-sideHeader info' data-toggle='tooltip') Select from uploaded expression data, or use data from the Expression Database
+                p(class='sideHeader info' data-toggle='tooltip') Select from user-uploaded expression data, or use data from our Expression Database
                 p(class='sideHeader info' data-toggle='tooltip') Top Dataset
                 select(id="dataset-top")
                 form
@@ -382,7 +382,7 @@ html
                   input(type='number' min='1' max='100' step='1' id='log-fold-change-max-value-sidebar' class='logFoldChangeMaxValue' aria-describedby='basic-addon1')
                   button(type="button" class='btn btn-default s' id="log-fold-change-button") Set
                 div(class="node-coloring-legend")
-                div(class="expression-db-loader-text") Node Coloring is Loading
+                div(class="expression-db-loader-text") Expression Database is Loading
                 div(class="expression-db-loader")
 
         div(class='edge-weight-sidebar disabled panel panel-default disabled')

--- a/web-client/views/upload.jade
+++ b/web-client/views/upload.jade
@@ -61,6 +61,11 @@ html
                       a(href='#' id='exportAsUnweightedGraphMl') To Unweighted GraphML
                     li(class='startDisabled disabled weighted export')
                       a(href='#' id='exportAsWeightedGraphMl') To Weighted GraphML
+                    li(class='divider')
+                    li(class='startDisabled disabled unweighted export')
+                      a(href='#' id='exportAsUnweightedExcel') To Unweighted Excel
+                    li(class='startDisabled disabled weighted export')
+                      a(href='#' id='exportAsWeightedExcel') To Weighted Excel
 
                 li(class='dropdown-submenu')
                   a(href='#')


### PR DESCRIPTION
As I outlined in #838 I have:
* added the export to excel feature
* figured out how to connect the official database to GRNsight (we still need to toggle stuff on the EC2 so it can run eternally on beta)
* populated this database
* made it so the checkbox to enable node coloring is initially unchecked (this was decently difficult because there are a few different ways in which node coloring is tracked and I had to figure out how to make it so the unchecked box meant the node coloring wouldn't happen, while also figuring out how to change it from the default of coloring automatically)
* made it so the color legend bar as well as its headers, options, and buttons, don't show up until node coloring is happening (goes along with a comment made in #837 ) -- I thought this was better than just having the bar constantly there because there seem to be some more complex methods attached to producing the color bar that I didn't want to disrupt
* adjusted "no expression data" warning to mention the expression database coloring option
* got rid of the weird extension that @dondi pointed out last week that was at the end of my API call
* node coloring using the db now works on the demo sets interestingly enough
* took care of the other notes @kdahlquist made on #837 
* made it so coloring a workbook that already has expression data using data from the database works
* made it so top and bottom dataset differentiation can happen smoothly using expression db data

I have a couple bugs that I'm still working on. Namely:
* when loaded after a wkbk with expression data, node coloring on a sheet without expression data using expression db has challenges
* need to make it so that, when a wkbk without expression data is colored using the db, it doesn't have to reload the expression data each time something is changed (switching to grid layout, for instance)

I thought I'd handled this first bug, but it came back when I refactored things a little to try and fix the second bug. Beyond this, I'm sure there will be other specific bugs that will make themselves clearer as we keep testing things out. Overall, the node coloring works very well and is decently quick. We will also just need to connect the GRNsight RDS to beta and everything should be good to go!