### PR TITLE
Fixed bug #832

### DIFF
--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -465,7 +465,7 @@ export var drawGraph = function (network) {
         }).style("stroke", function (d) {
             if (unweighted || !grnState.colorOptimal) {
                 return "black";
-            } else if (normalize(d).toPrecision(4) <= grayThreshold) {
+            } else if (normalize(d) <= grayThreshold) {
                 return "gray";
             } else {
                 return d.stroke;
@@ -481,7 +481,7 @@ export var drawGraph = function (network) {
             var xOffsets;
             var color;
 
-            if (normalize(d).toPrecision(4) <= grayThreshold) {
+            if (normalize(d) <= grayThreshold) {
                 minimum = "gray";
             }
             if ( x1 === x2 && y1 === y2 ) {
@@ -532,7 +532,7 @@ export var drawGraph = function (network) {
                         .attr("rx", 10)
                         .attr("ry", 10)
                         .attr("style", function () {
-                            if ( normalize(d).toPrecision(4) <= grayThreshold) {
+                            if ( normalize(d) <= grayThreshold) {
                                 color = "gray";
                             } else {
                                 color = d.stroke;
@@ -581,7 +581,7 @@ export var drawGraph = function (network) {
                         .attr("rx", 10)
                         .attr("ry", 10)
                         .attr("style", function () {
-                            if (normalize(d).toPrecision(4) <= grayThreshold) {
+                            if (normalize(d) <= grayThreshold) {
                                 color = "gray";
                             } else {
                                 color = d.stroke;
@@ -644,7 +644,7 @@ export var drawGraph = function (network) {
                         .attr("style", function () {
                             if (unweighted || !grnState.colorOptimal) {
                                 color = "black";
-                            } else if ( normalize(d).toPrecision(4) <= grayThreshold) {
+                            } else if ( normalize(d) <= grayThreshold) {
                                 color = "gray";
                             } else {
                                 color = d.stroke;
@@ -1446,7 +1446,7 @@ export var drawGraph = function (network) {
                 var minimum = "";
                 var selfRef = "";
 
-                if (normalize(d).toPrecision(4) <= grayThreshold) {
+                if (normalize(d) <= grayThreshold) {
                     minimum = "gray";
                 }
 
@@ -1478,7 +1478,7 @@ export var drawGraph = function (network) {
     }
 
     function normalize (d) {
-        return Math.abs(d.value / maxWeight);
+        return Math.abs(d.value / maxWeight).toPrecision(4);
     }
 
     function dragstart (d) {

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -465,7 +465,7 @@ export var drawGraph = function (network) {
         }).style("stroke", function (d) {
             if (unweighted || !grnState.colorOptimal) {
                 return "black";
-            } else if (normalize(d) <= grayThreshold) {
+            } else if (normalize(d).toPrecision(4) <= grayThreshold) {
                 return "gray";
             } else {
                 return d.stroke;
@@ -481,7 +481,7 @@ export var drawGraph = function (network) {
             var xOffsets;
             var color;
 
-            if (Math.abs(d.value / maxWeight) <= grayThreshold) {
+            if (normalize(d).toPrecision(4) <= grayThreshold) {
                 minimum = "gray";
             }
             if ( x1 === x2 && y1 === y2 ) {
@@ -532,7 +532,7 @@ export var drawGraph = function (network) {
                         .attr("rx", 10)
                         .attr("ry", 10)
                         .attr("style", function () {
-                            if ( normalize(d) <= grayThreshold) {
+                            if ( normalize(d).toPrecision(4) <= grayThreshold) {
                                 color = "gray";
                             } else {
                                 color = d.stroke;
@@ -581,7 +581,7 @@ export var drawGraph = function (network) {
                         .attr("rx", 10)
                         .attr("ry", 10)
                         .attr("style", function () {
-                            if (normalize(d) <= grayThreshold) {
+                            if (normalize(d).toPrecision(4) <= grayThreshold) {
                                 color = "gray";
                             } else {
                                 color = d.stroke;
@@ -644,7 +644,7 @@ export var drawGraph = function (network) {
                         .attr("style", function () {
                             if (unweighted || !grnState.colorOptimal) {
                                 color = "black";
-                            } else if ( normalize(d) <= grayThreshold) {
+                            } else if ( normalize(d).toPrecision(4) <= grayThreshold) {
                                 color = "gray";
                             } else {
                                 color = d.stroke;
@@ -1446,7 +1446,7 @@ export var drawGraph = function (network) {
                 var minimum = "";
                 var selfRef = "";
 
-                if (normalize(d) <= grayThreshold) {
+                if (normalize(d).toPrecision(4) <= grayThreshold) {
                     minimum = "gray";
                 }
 


### PR DESCRIPTION
Fixes issue #832 - Gray Edge Threshold set to 100% should make all edges gray. 

This bug occurred when the edge in question had a weight with precision higher than 3 decimal places due to the rounding of maxWeight in the code. Solved by rounding the comparison value before comparing to grayThreshold.

Changes noted in commit messages:
1. Changed line 484 to use 'normalize' function instead of performing operation inline. This format follows the convention elsewhere in code (not an error; just styling)
2. Changed all lines comparing normalize(d) to grayThreshold to round the result of normalize. 
    "normalize(d).toPrecision(4) <= grayThreshold"
