### PR TITLE
New fix for #444 for non-self-referential edges to preserve the arcs.

### DIFF
--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -698,7 +698,7 @@ export var drawGraph = function (network) {
     };
 
     var CURVE_THRESHOLD = 200;
-    var EDGE_OFFSET = 50; // Forces edge to curve inwards when at an edge
+    var EDGE_OFFSET = 20;
     var lineTo = function (d) {
         var node = d3.select("#node" + d.target.index);
         var w = +node.attr("width");
@@ -745,14 +745,14 @@ export var drawGraph = function (network) {
         var cp2x = x2 - inlineOffset * ux + vx * orthoOffset;
         var cp2y = y2 - inlineOffset * uy + vy * orthoOffset;
 
-        cp1x = Math.min(Math.max(0, cp1x), width - EDGE_OFFSET);
-        cp1y = Math.min(Math.max(EDGE_OFFSET, cp1y), height - EDGE_OFFSET);
-        cp2x = Math.min(Math.max(0, cp2x), width - EDGE_OFFSET);
-        cp2y = Math.min(Math.max(EDGE_OFFSET, cp2y), height - EDGE_OFFSET);
+        cp1x = Math.min(Math.max(0, cp1x), width);
+        cp1y = Math.min(Math.max(0, cp1y), height);
+        cp2x = Math.min(Math.max(0, cp2x), width);
+        cp2y = Math.min(Math.max(0, cp2y), height);
 
         d.label = {
-            x: (x1 + cp1x + cp2x + x2) / 4,
-            y: (y1 + cp1y + cp2y + y2) / 4
+            x: Math.min(Math.max((x1 + cp1x + cp2x + x2) / 4, EDGE_OFFSET), width - 2 * EDGE_OFFSET),
+            y: Math.min(Math.max((y1 + cp1y + cp2y + y2) / 4, EDGE_OFFSET), height - EDGE_OFFSET)
         };
 
         return "C" + cp1x + " " + cp1y + ", " +


### PR DESCRIPTION
A quick fix for #444 by forcing weights to stay in the bounds with an offset of 20.

I will keep this on my radar for a better arc calculation and work on a non-magic number edge offset (something based on the precision of the number), but this will definitely work for now. Keeps weights within the boundary 