### PR TITLE
Fixed demo files 3 and 4 to not export legacy 3 column sheets

### DIFF
--- a/server/controllers/demo-workbooks.js
+++ b/server/controllers/demo-workbooks.js
@@ -4623,56 +4623,56 @@ var demoWorkbook3 = function (path, res, app) {
             }
         },
         test: {
-            production_rates: {
-                data: {
-                    YKL112W: "ABF1",
-                    YLR131C: "ACE2",
-                    YGL071W: "AFT1",
-                    YOR028C: "CIN5",
-                    YPL177C: "CUP9",
-                    YPR104C: "FHL1",
-                    YGL181W: "GTS1",
-                    YOL089C: "HAL9",
-                    YGL073W: "HSF1",
-                    YMR021C: "MAC1",
-                    YOL116W: "MSN1",
-                    YKL062W: "MSN4",
-                    YDR043C: "NRG1",
-                    YKL043W: "PHD1",
-                    YNL216W: "RAP1",
-                    YBR049C: "REB1",
-                    YPR065W: "ROX1",
-                    YER169W: "RPH1",
-                    YHR206W: "SKN7",
-                    YML007W: "YAP1",
-                    YDR259C: "YAP6"
-                }
-            },
-            degradation_rates: {
-                data : {
-                    YKL112W: "ABF1",
-                    YLR131C: "ACE2",
-                    YGL071W: "AFT1",
-                    YOR028C: "CIN5",
-                    YPL177C: "CUP9",
-                    YPR104C: "FHL1",
-                    YGL181W: "GTS1",
-                    YOL089C: "HAL9",
-                    YGL073W: "HSF1",
-                    YMR021C: "MAC1",
-                    YOL116W: "MSN1",
-                    YKL062W: "MSN4",
-                    YDR043C: "NRG1",
-                    YKL043W: "PHD1",
-                    YNL216W: "RAP1",
-                    YBR049C: "REB1",
-                    YPR065W: "ROX1",
-                    YER169W: "RPH1",
-                    YHR206W: "SKN7",
-                    YML007W: "YAP1",
-                    YDR259C: "YAP6"
-                }
-            }
+            // production_rates: {
+            //     data: {
+            //         YKL112W: "ABF1",
+            //         YLR131C: "ACE2",
+            //         YGL071W: "AFT1",
+            //         YOR028C: "CIN5",
+            //         YPL177C: "CUP9",
+            //         YPR104C: "FHL1",
+            //         YGL181W: "GTS1",
+            //         YOL089C: "HAL9",
+            //         YGL073W: "HSF1",
+            //         YMR021C: "MAC1",
+            //         YOL116W: "MSN1",
+            //         YKL062W: "MSN4",
+            //         YDR043C: "NRG1",
+            //         YKL043W: "PHD1",
+            //         YNL216W: "RAP1",
+            //         YBR049C: "REB1",
+            //         YPR065W: "ROX1",
+            //         YER169W: "RPH1",
+            //         YHR206W: "SKN7",
+            //         YML007W: "YAP1",
+            //         YDR259C: "YAP6"
+            //     }
+            // },
+            // degradation_rates: {
+            //     data : {
+            //         YKL112W: "ABF1",
+            //         YLR131C: "ACE2",
+            //         YGL071W: "AFT1",
+            //         YOR028C: "CIN5",
+            //         YPL177C: "CUP9",
+            //         YPR104C: "FHL1",
+            //         YGL181W: "GTS1",
+            //         YOL089C: "HAL9",
+            //         YGL073W: "HSF1",
+            //         YMR021C: "MAC1",
+            //         YOL116W: "MSN1",
+            //         YKL062W: "MSN4",
+            //         YDR043C: "NRG1",
+            //         YKL043W: "PHD1",
+            //         YNL216W: "RAP1",
+            //         YBR049C: "REB1",
+            //         YPR065W: "ROX1",
+            //         YER169W: "RPH1",
+            //         YHR206W: "SKN7",
+            //         YML007W: "YAP1",
+            //         YDR259C: "YAP6"
+            //     }
+            // }
         },
         expression: {
             wt_log2_expression: {
@@ -5735,56 +5735,56 @@ var demoWorkbook4 = function (path, res, app) {
             }
         },
         test: {
-            production_rates: {
-                data: {
-                    YKL112W: "ABF1",
-                    YLR131C: "ACE2",
-                    YGL071W: "AFT1",
-                    YOR028C: "CIN5",
-                    YPL177C: "CUP9",
-                    YPR104C: "FHL1",
-                    YGL181W: "GTS1",
-                    YOL089C: "HAL9",
-                    YGL073W: "HSF1",
-                    YMR021C: "MAC1",
-                    YOL116W: "MSN1",
-                    YKL062W: "MSN4",
-                    YDR043C: "NRG1",
-                    YKL043W: "PHD1",
-                    YNL216W: "RAP1",
-                    YBR049C: "REB1",
-                    YPR065W: "ROX1",
-                    YER169W: "RPH1",
-                    YHR206W: "SKN7",
-                    YML007W: "YAP1",
-                    YDR259C: "YAP6"
-                }
-            },
-            degradation_rates: {
-                data : {
-                    YKL112W: "ABF1",
-                    YLR131C: "ACE2",
-                    YGL071W: "AFT1",
-                    YOR028C: "CIN5",
-                    YPL177C: "CUP9",
-                    YPR104C: "FHL1",
-                    YGL181W: "GTS1",
-                    YOL089C: "HAL9",
-                    YGL073W: "HSF1",
-                    YMR021C: "MAC1",
-                    YOL116W: "MSN1",
-                    YKL062W: "MSN4",
-                    YDR043C: "NRG1",
-                    YKL043W: "PHD1",
-                    YNL216W: "RAP1",
-                    YBR049C: "REB1",
-                    YPR065W: "ROX1",
-                    YER169W: "RPH1",
-                    YHR206W: "SKN7",
-                    YML007W: "YAP1",
-                    YDR259C: "YAP6"
-                }
-            }
+            // production_rates: {
+            //     data: {
+            //         YKL112W: "ABF1",
+            //         YLR131C: "ACE2",
+            //         YGL071W: "AFT1",
+            //         YOR028C: "CIN5",
+            //         YPL177C: "CUP9",
+            //         YPR104C: "FHL1",
+            //         YGL181W: "GTS1",
+            //         YOL089C: "HAL9",
+            //         YGL073W: "HSF1",
+            //         YMR021C: "MAC1",
+            //         YOL116W: "MSN1",
+            //         YKL062W: "MSN4",
+            //         YDR043C: "NRG1",
+            //         YKL043W: "PHD1",
+            //         YNL216W: "RAP1",
+            //         YBR049C: "REB1",
+            //         YPR065W: "ROX1",
+            //         YER169W: "RPH1",
+            //         YHR206W: "SKN7",
+            //         YML007W: "YAP1",
+            //         YDR259C: "YAP6"
+            //     }
+            // },
+            // degradation_rates: {
+            //     data : {
+            //         YKL112W: "ABF1",
+            //         YLR131C: "ACE2",
+            //         YGL071W: "AFT1",
+            //         YOR028C: "CIN5",
+            //         YPL177C: "CUP9",
+            //         YPR104C: "FHL1",
+            //         YGL181W: "GTS1",
+            //         YOL089C: "HAL9",
+            //         YGL073W: "HSF1",
+            //         YMR021C: "MAC1",
+            //         YOL116W: "MSN1",
+            //         YKL062W: "MSN4",
+            //         YDR043C: "NRG1",
+            //         YKL043W: "PHD1",
+            //         YNL216W: "RAP1",
+            //         YBR049C: "REB1",
+            //         YPR065W: "ROX1",
+            //         YER169W: "RPH1",
+            //         YHR206W: "SKN7",
+            //         YML007W: "YAP1",
+            //         YDR259C: "YAP6"
+            //     }
+            // }
         },
         expression: {
             wt_log2_expression: {

--- a/server/controllers/demo-workbooks.js
+++ b/server/controllers/demo-workbooks.js
@@ -4622,58 +4622,7 @@ var demoWorkbook3 = function (path, res, app) {
                 taxon_id: 559292
             }
         },
-        test: {
-            // production_rates: {
-            //     data: {
-            //         YKL112W: "ABF1",
-            //         YLR131C: "ACE2",
-            //         YGL071W: "AFT1",
-            //         YOR028C: "CIN5",
-            //         YPL177C: "CUP9",
-            //         YPR104C: "FHL1",
-            //         YGL181W: "GTS1",
-            //         YOL089C: "HAL9",
-            //         YGL073W: "HSF1",
-            //         YMR021C: "MAC1",
-            //         YOL116W: "MSN1",
-            //         YKL062W: "MSN4",
-            //         YDR043C: "NRG1",
-            //         YKL043W: "PHD1",
-            //         YNL216W: "RAP1",
-            //         YBR049C: "REB1",
-            //         YPR065W: "ROX1",
-            //         YER169W: "RPH1",
-            //         YHR206W: "SKN7",
-            //         YML007W: "YAP1",
-            //         YDR259C: "YAP6"
-            //     }
-            // },
-            // degradation_rates: {
-            //     data : {
-            //         YKL112W: "ABF1",
-            //         YLR131C: "ACE2",
-            //         YGL071W: "AFT1",
-            //         YOR028C: "CIN5",
-            //         YPL177C: "CUP9",
-            //         YPR104C: "FHL1",
-            //         YGL181W: "GTS1",
-            //         YOL089C: "HAL9",
-            //         YGL073W: "HSF1",
-            //         YMR021C: "MAC1",
-            //         YOL116W: "MSN1",
-            //         YKL062W: "MSN4",
-            //         YDR043C: "NRG1",
-            //         YKL043W: "PHD1",
-            //         YNL216W: "RAP1",
-            //         YBR049C: "REB1",
-            //         YPR065W: "ROX1",
-            //         YER169W: "RPH1",
-            //         YHR206W: "SKN7",
-            //         YML007W: "YAP1",
-            //         YDR259C: "YAP6"
-            //     }
-            // }
-        },
+        test: {},
         expression: {
             wt_log2_expression: {
                 errors: [],
@@ -5734,58 +5683,7 @@ var demoWorkbook4 = function (path, res, app) {
                 taxon_id: 559292
             }
         },
-        test: {
-            // production_rates: {
-            //     data: {
-            //         YKL112W: "ABF1",
-            //         YLR131C: "ACE2",
-            //         YGL071W: "AFT1",
-            //         YOR028C: "CIN5",
-            //         YPL177C: "CUP9",
-            //         YPR104C: "FHL1",
-            //         YGL181W: "GTS1",
-            //         YOL089C: "HAL9",
-            //         YGL073W: "HSF1",
-            //         YMR021C: "MAC1",
-            //         YOL116W: "MSN1",
-            //         YKL062W: "MSN4",
-            //         YDR043C: "NRG1",
-            //         YKL043W: "PHD1",
-            //         YNL216W: "RAP1",
-            //         YBR049C: "REB1",
-            //         YPR065W: "ROX1",
-            //         YER169W: "RPH1",
-            //         YHR206W: "SKN7",
-            //         YML007W: "YAP1",
-            //         YDR259C: "YAP6"
-            //     }
-            // },
-            // degradation_rates: {
-            //     data : {
-            //         YKL112W: "ABF1",
-            //         YLR131C: "ACE2",
-            //         YGL071W: "AFT1",
-            //         YOR028C: "CIN5",
-            //         YPL177C: "CUP9",
-            //         YPR104C: "FHL1",
-            //         YGL181W: "GTS1",
-            //         YOL089C: "HAL9",
-            //         YGL073W: "HSF1",
-            //         YMR021C: "MAC1",
-            //         YOL116W: "MSN1",
-            //         YKL062W: "MSN4",
-            //         YDR043C: "NRG1",
-            //         YKL043W: "PHD1",
-            //         YNL216W: "RAP1",
-            //         YBR049C: "REB1",
-            //         YPR065W: "ROX1",
-            //         YER169W: "RPH1",
-            //         YHR206W: "SKN7",
-            //         YML007W: "YAP1",
-            //         YDR259C: "YAP6"
-            //     }
-            // }
-        },
+        test: {},
         expression: {
             wt_log2_expression: {
                 errors: [],


### PR DESCRIPTION
Demo 3 and 4 export properly and re-import without warnings/ errors referenced in #907 

Pull Request Checklist
- [x] Travis C.I. build passes
- [x] All four Demos look as expected when loaded
- [x] Reload works as expected
- [x] Loading file with Error brings up error modal, and it looks as expected
- [x] Loading file with Warning brings up warnings modal
- [x] Import works for both SIF and GraphML
- [x] Graph can be exported to SIF and GraphML
- [x] Print works as expected
- [x] Restrict graph to viewport works as expected (check/uncheck)
- [x] Viewport Size Changing works as expected (small/medium/large/fit)
- [x] Toggle between Grid Layout and Force Graph Layout works as expected
- [x] Force Graph Parameter Sliders change the number above them and have an effect on the graph
- [x] Locking/Unlocking/Resetting/Undo Resetting the force graph parameters works as expected
- [x] Enabling and disabling node coloring works as expected
- [x] Node coloring options work as expected (selection top/bottom dataset, averaging values, changing max value)
- [x] Weighted graph loaded with the "default to black edges" option checked appears as expected
- [x] Hide/Show Weights works as expected (always/never/upon mouseover)
- [x] Edge Weight Normalization Factor can be changed (set/reset)
- [x] Gray Edge Threshold can be changed, slider changes the number and has an effect on the graph
- [x] Checking Show Gray Edges as Dashed works as expected (check/uncheck)
- [x] D-pad left/right/top/bottom/center works as expected
- [x] Zoom slider changes number and has effect on graph (viewport and menu)
- [x] Right click on a node opens gene page, page is populated with correct data

