### PR TITLE
Igreen1

### DIFF
--- a/web-client/public/js/constants.js
+++ b/web-client/public/js/constants.js
@@ -155,4 +155,22 @@ export const ZOOM_ADAPTIVE_MAX_SCALE                    = 4;
 export const ZOOM_SLIDER                                = "#zoomSlider";
 export const ZOOM_INPUT                                 = "#zoomInput";
 export const ZOOM_PERCENT                               = "#zoomPercent";
+
 export const VIEWPORT_FIT                               = "containerFit";
+export const VIEWPORT_S                               = "containerS";
+export const VIEWPORT_M                               = "containerM";
+export const VIEWPORT_L                               = "containerL";
+
+export const VIEWPORT_SIZE_S_DROPDOWN                   = "#viewport-size-s";
+export const VIEWPORT_SIZE_M_DROPDOWN                   = "#viewport-size-m";
+export const VIEWPORT_SIZE_L_DROPDOWN                   = "#viewport-size-l";
+export const VIEWPORT_SIZE_FIT_DROPDOWN                 = "#viewport-size-fit";
+export const VIEWPORT_SIZE_S_SIDEBAR                    = "#boundBoxS";
+export const VIEWPORT_SIZE_M_SIDEBAR                    = "#boundBoxM";
+export const VIEWPORT_SIZE_L_SIDEBAR                    = "#boundBoxL";
+export const VIEWPORT_SIZE_FIT_SIDEBAR                  = "#boundBoxFit";
+export const VIEWPORT_OPTION_CLASS                      = ".viewportOption";
+export const VIEWPORT_OPTION_CLASS_SIDEBAR              = ".boundBoxSize";
+
+
+

--- a/web-client/public/js/container.js
+++ b/web-client/public/js/container.js
@@ -50,18 +50,7 @@ export const container = function () {
         });
     }
 
-    requestWindowDimensions();
-
-    if (pageWidth < MEDIUM_PAGE_WIDTH) {
-        $("#boundBoxS").prop("checked", true);
-        container.addClass("containerS");
-    } else if (pageWidth > MEDIUM_PAGE_WIDTH && pageWidth < LARGE_PAGE_WIDTH) {
-        $("#boundBoxM").prop("checked", true);
-        container.addClass("containerM");
-    } else {
-        $("#boundBoxL").prop("checked", true);
-        container.addClass("containerL");
-    }
+    
 
     var setSizeIndicator = function (selector) {
         $("#viewport-size-s span, #viewport-size-m span, #viewport-size-l span, #viewport-size-fit span")
@@ -84,6 +73,22 @@ export const container = function () {
     var fit = function () {
         setSizeIndicator("#viewport-size-fit span");
     };
+
+    requestWindowDimensions();
+
+    if (pageWidth < MEDIUM_PAGE_WIDTH) {
+        $("#boundBoxS").prop("checked", true);
+        small();
+        container.addClass("containerS");
+    } else if (pageWidth > MEDIUM_PAGE_WIDTH && pageWidth < LARGE_PAGE_WIDTH) {
+        $("#boundBoxM").prop("checked", true);
+        medium();
+        container.addClass("containerM");
+    } else {
+        $("#boundBoxL").prop("checked", true);
+        large();
+        container.addClass("containerL");
+    }
 
     $("#viewport-size-s").on("click", function () {
         $("#boundBoxS").prop("checked", true).trigger("click");

--- a/web-client/public/js/container.js
+++ b/web-client/public/js/container.js
@@ -51,28 +51,6 @@ export const container = function (grnState) {
         });
     }
 
-    // var setSizeIndicator = function (selector) {
-    //     $("#viewport-size-s span, #viewport-size-m span, #viewport-size-l span, #viewport-size-fit span")
-    //       .removeClass("glyphicon-ok");
-    //     $(selector).addClass("glyphicon-ok");
-    // };
-
-    // var small = function () {
-    //     setSizeIndicator("#viewport-size-s span");
-    // };
-
-    // var medium = function () {
-    //     setSizeIndicator("#viewport-size-m span");
-    // };
-
-    // var large = function () {
-    //     setSizeIndicator("#viewport-size-l span");
-    // };
-
-    // var fit = function () {
-    //     setSizeIndicator("#viewport-size-fit span");
-    // };
-
     requestWindowDimensions();
 
     if (pageWidth < MEDIUM_PAGE_WIDTH) {
@@ -83,46 +61,6 @@ export const container = function (grnState) {
         grnState.viewportSize = "containerL";
     }
     updateApp(grnState);
-
-    // $("#viewport-size-s").on("click", function () {
-    //     $("#boundBoxS").prop("checked", true).trigger("click");
-    //     small();
-    // });
-
-    // $("#boundBoxS").on("click", function () {
-    //     $("#boundBoxS").prop("checked", true);
-    //     small();
-    // });
-
-    // $("#viewport-size-m").on("click", function () {
-    //     $("#boundBoxM").prop("checked", true).trigger("click");
-    //     medium();
-    // });
-
-    // $("#boundBoxM").on("click", function () {
-    //     $("#viewport-size-m").prop("checked", true);
-    //     medium();
-    // });
-
-    // $("#viewport-size-l").on("click", function () {
-    //     $("#boundBoxL").prop("checked", true).trigger("click");
-    //     large();
-    // });
-
-    // $("#boundBoxL").on("click", function () {
-    //     $("#viewport-size-l").prop("checked", true);
-    //     large();
-    // });
-
-    // $("#viewport-size-fit").on("click", function () {
-    //     $("#boundBoxFit").prop("checked", true).trigger("click");
-    //     fit();
-    // });
-
-    // $("#boundBoxFit").on("click", function () {
-    //     $("#viewport-size-fit").prop("checked", true);
-    //     fit();
-    // });
 
     $("#restrict-graph-to-viewport").on("click", function () {
         if ($(".viewport").prop("checked")) {
@@ -144,17 +82,4 @@ export const container = function (grnState) {
             $("#expressionDB").trigger("change");
         }
     });
-
-    // $(".boundBoxSize").on("click", function () {
-    //     var currentValue = $(this).val();
-    //     var grnsightContainerClass = `grnsight-container ${currentValue}`;
-    //     if (!container.hasClass(currentValue)) {
-    //         container.attr("class", grnsightContainerClass);
-    //         if (currentValue === VIEWPORT_FIT) {
-    //             requestWindowDimensions();
-    //         } else {
-    //             container.css({ width: "", height: "" });
-    //         }
-    //     }
-    // });
 };

--- a/web-client/public/js/container.js
+++ b/web-client/public/js/container.js
@@ -90,45 +90,45 @@ export const container = function () {
         container.addClass("containerL");
     }
 
-    $("#viewport-size-s").on("click", function () {
-        $("#boundBoxS").prop("checked", true).trigger("click");
-        small();
-    });
+    // $("#viewport-size-s").on("click", function () {
+    //     $("#boundBoxS").prop("checked", true).trigger("click");
+    //     small();
+    // });
 
-    $("#boundBoxS").on("click", function () {
-        $("#boundBoxS").prop("checked", true);
-        small();
-    });
+    // $("#boundBoxS").on("click", function () {
+    //     $("#boundBoxS").prop("checked", true);
+    //     small();
+    // });
 
-    $("#viewport-size-m").on("click", function () {
-        $("#boundBoxM").prop("checked", true).trigger("click");
-        medium();
-    });
+    // $("#viewport-size-m").on("click", function () {
+    //     $("#boundBoxM").prop("checked", true).trigger("click");
+    //     medium();
+    // });
 
-    $("#boundBoxM").on("click", function () {
-        $("#viewport-size-m").prop("checked", true);
-        medium();
-    });
+    // $("#boundBoxM").on("click", function () {
+    //     $("#viewport-size-m").prop("checked", true);
+    //     medium();
+    // });
 
-    $("#viewport-size-l").on("click", function () {
-        $("#boundBoxL").prop("checked", true).trigger("click");
-        large();
-    });
+    // $("#viewport-size-l").on("click", function () {
+    //     $("#boundBoxL").prop("checked", true).trigger("click");
+    //     large();
+    // });
 
-    $("#boundBoxL").on("click", function () {
-        $("#viewport-size-l").prop("checked", true);
-        large();
-    });
+    // $("#boundBoxL").on("click", function () {
+    //     $("#viewport-size-l").prop("checked", true);
+    //     large();
+    // });
 
-    $("#viewport-size-fit").on("click", function () {
-        $("#boundBoxFit").prop("checked", true).trigger("click");
-        fit();
-    });
+    // $("#viewport-size-fit").on("click", function () {
+    //     $("#boundBoxFit").prop("checked", true).trigger("click");
+    //     fit();
+    // });
 
-    $("#boundBoxFit").on("click", function () {
-        $("#viewport-size-fit").prop("checked", true);
-        fit();
-    });
+    // $("#boundBoxFit").on("click", function () {
+    //     $("#viewport-size-fit").prop("checked", true);
+    //     fit();
+    // });
 
     $("#restrict-graph-to-viewport").on("click", function () {
         if ($(".viewport").prop("checked")) {
@@ -151,16 +151,16 @@ export const container = function () {
         }
     });
 
-    $(".boundBoxSize").on("click", function () {
-        var currentValue = $(this).val();
-        var grnsightContainerClass = `grnsight-container ${currentValue}`;
-        if (!container.hasClass(currentValue)) {
-            container.attr("class", grnsightContainerClass);
-            if (currentValue === VIEWPORT_FIT) {
-                requestWindowDimensions();
-            } else {
-                container.css({ width: "", height: "" });
-            }
-        }
-    });
+    // $(".boundBoxSize").on("click", function () {
+    //     var currentValue = $(this).val();
+    //     var grnsightContainerClass = `grnsight-container ${currentValue}`;
+    //     if (!container.hasClass(currentValue)) {
+    //         container.attr("class", grnsightContainerClass);
+    //         if (currentValue === VIEWPORT_FIT) {
+    //             requestWindowDimensions();
+    //         } else {
+    //             container.css({ width: "", height: "" });
+    //         }
+    //     }
+    // });
 };

--- a/web-client/public/js/container.js
+++ b/web-client/public/js/container.js
@@ -1,6 +1,7 @@
 import { VIEWPORT_FIT } from "./constants";
+import { updateApp } from "./update-app";
 
-export const container = function () {
+export const container = function (grnState) {
     var container = $(".grnsight-container");
     var pageWidth = $(window).width();
 
@@ -50,45 +51,38 @@ export const container = function () {
         });
     }
 
-    
+    // var setSizeIndicator = function (selector) {
+    //     $("#viewport-size-s span, #viewport-size-m span, #viewport-size-l span, #viewport-size-fit span")
+    //       .removeClass("glyphicon-ok");
+    //     $(selector).addClass("glyphicon-ok");
+    // };
 
-    var setSizeIndicator = function (selector) {
-        $("#viewport-size-s span, #viewport-size-m span, #viewport-size-l span, #viewport-size-fit span")
-          .removeClass("glyphicon-ok");
-        $(selector).addClass("glyphicon-ok");
-    };
+    // var small = function () {
+    //     setSizeIndicator("#viewport-size-s span");
+    // };
 
-    var small = function () {
-        setSizeIndicator("#viewport-size-s span");
-    };
+    // var medium = function () {
+    //     setSizeIndicator("#viewport-size-m span");
+    // };
 
-    var medium = function () {
-        setSizeIndicator("#viewport-size-m span");
-    };
+    // var large = function () {
+    //     setSizeIndicator("#viewport-size-l span");
+    // };
 
-    var large = function () {
-        setSizeIndicator("#viewport-size-l span");
-    };
-
-    var fit = function () {
-        setSizeIndicator("#viewport-size-fit span");
-    };
+    // var fit = function () {
+    //     setSizeIndicator("#viewport-size-fit span");
+    // };
 
     requestWindowDimensions();
 
     if (pageWidth < MEDIUM_PAGE_WIDTH) {
-        $("#boundBoxS").prop("checked", true);
-        small();
-        container.addClass("containerS");
+        grnState.viewportSize = "containerS";
     } else if (pageWidth > MEDIUM_PAGE_WIDTH && pageWidth < LARGE_PAGE_WIDTH) {
-        $("#boundBoxM").prop("checked", true);
-        medium();
-        container.addClass("containerM");
+        grnState.viewportSize = "containerM";
     } else {
-        $("#boundBoxL").prop("checked", true);
-        large();
-        container.addClass("containerL");
+        grnState.viewportSize = "containerL";
     }
+    updateApp(grnState);
 
     // $("#viewport-size-s").on("click", function () {
     //     $("#boundBoxS").prop("checked", true).trigger("click");

--- a/web-client/public/js/grnsight.js
+++ b/web-client/public/js/grnsight.js
@@ -9,5 +9,5 @@ import { setupHandlers } from "./setup-handlers";
 setupHandlers(grnState);
 updateApp(grnState);
 
-container();
+container(grnState);
 upload();

--- a/web-client/public/js/grnstate.js
+++ b/web-client/public/js/grnstate.js
@@ -9,7 +9,8 @@ import {
   CHARGE_DEFAULT_VALUE,
   DEFAULT_MAX_LOG_FOLD_CHANGE,
   DEFAULT_ZOOM_VALUE,
-  FORCE_GRAPH
+  FORCE_GRAPH,
+  VIEWPORT_FIT
 } from "./constants";
 let currentWorkbook = null;
 
@@ -139,5 +140,8 @@ export const grnState = {
     },
 
 // Graph Layout Parameter
-    graphLayout: FORCE_GRAPH
+    graphLayout: FORCE_GRAPH,
+
+// Viewport Size Parameter
+    viewportSize: VIEWPORT_FIT,
 };

--- a/web-client/public/js/setup-handlers.js
+++ b/web-client/public/js/setup-handlers.js
@@ -347,15 +347,15 @@ export const setupHandlers = grnState => {
         updateApp(grnState);
     });
 
-    $(VIEWPORT_OPTION_CLASS_SIDEBAR).click(function(){
-        grnState.viewportSize = $(this).val()
-        updateApp(grnState)
-    })
+    $(VIEWPORT_OPTION_CLASS_SIDEBAR).click(function () {
+        grnState.viewportSize = $(this).val();
+        updateApp(grnState);
+    });
 
-    $(VIEWPORT_OPTION_CLASS).click(function(){
-        grnState.viewportSize = $(this).attr("value")
-        updateApp(grnState)
-    })
+    $(VIEWPORT_OPTION_CLASS).click(function () {
+        grnState.viewportSize = $(this).attr("value");
+        updateApp(grnState);
+    });
 
     $(RESET_SLIDERS_CLASS).click(() => {
         grnState.chargeSlider.backup = grnState.chargeSlider.currentVal;

--- a/web-client/public/js/setup-handlers.js
+++ b/web-client/public/js/setup-handlers.js
@@ -61,7 +61,9 @@ import {
     SPECIES_BUTTON_HUMAN,
     SPECIES_BUTTON_MOUSE,
     SPECIES_BUTTON_NEMATODE,
-    SPECIES_BUTTON_YEAST
+    SPECIES_BUTTON_YEAST,
+    VIEWPORT_OPTION_CLASS,
+    VIEWPORT_OPTION_CLASS_SIDEBAR
 } from "./constants";
 
 import { setupLoadAndImportHandlers } from "./setup-load-and-import-handlers";
@@ -344,6 +346,21 @@ export const setupHandlers = grnState => {
         }
         updateApp(grnState);
     });
+
+    $(VIEWPORT_OPTION_CLASS_SIDEBAR).click(function(){
+        console.log(this)
+        console.log("click detected")
+        grnState.viewportSize = $(this).val()
+        updateApp(grnState)
+    })
+
+    $(VIEWPORT_OPTION_CLASS).click(function(){
+        console.log(this)
+        console.log($(this).attr("value"))
+        console.log("click detected")
+        grnState.viewportSize = $(this).attr("value")
+        updateApp(grnState)
+    })
 
     $(RESET_SLIDERS_CLASS).click(() => {
         grnState.chargeSlider.backup = grnState.chargeSlider.currentVal;

--- a/web-client/public/js/setup-handlers.js
+++ b/web-client/public/js/setup-handlers.js
@@ -348,16 +348,11 @@ export const setupHandlers = grnState => {
     });
 
     $(VIEWPORT_OPTION_CLASS_SIDEBAR).click(function(){
-        console.log(this)
-        console.log("click detected")
         grnState.viewportSize = $(this).val()
         updateApp(grnState)
     })
 
     $(VIEWPORT_OPTION_CLASS).click(function(){
-        console.log(this)
-        console.log($(this).attr("value"))
-        console.log("click detected")
         grnState.viewportSize = $(this).attr("value")
         updateApp(grnState)
     })

--- a/web-client/public/js/update-app.js
+++ b/web-client/public/js/update-app.js
@@ -223,10 +223,10 @@ const synchronizeHideAllWeights = () => {
 
 // Viewport
 const synchronizeViewportSizeSmall = () => {
-    $(VIEWPORT_SIZE_S_DROPDOWN + " span").removeClass("glyphicon-ok")
-    $(VIEWPORT_SIZE_M_DROPDOWN + " span").removeClass("glyphicon-ok")
-    $(VIEWPORT_SIZE_L_DROPDOWN + " span").removeClass("glyphicon-ok")
-    $(VIEWPORT_SIZE_FIT_DROPDOWN + " span").removeClass("glyphicon-ok")
+    $(VIEWPORT_SIZE_S_DROPDOWN + " span").removeClass("glyphicon-ok");
+    $(VIEWPORT_SIZE_M_DROPDOWN + " span").removeClass("glyphicon-ok");
+    $(VIEWPORT_SIZE_L_DROPDOWN + " span").removeClass("glyphicon-ok");
+    $(VIEWPORT_SIZE_FIT_DROPDOWN + " span").removeClass("glyphicon-ok");
 
     $(VIEWPORT_SIZE_S_SIDEBAR).removeProp("checked");
     $(VIEWPORT_SIZE_M_SIDEBAR).removeProp("checked");
@@ -235,13 +235,13 @@ const synchronizeViewportSizeSmall = () => {
 
     $(VIEWPORT_SIZE_S_SIDEBAR).prop("checked", "checked");
     $(VIEWPORT_SIZE_S_DROPDOWN + " span").addClass("glyphicon-ok");
-}
+};
 
 const synchronizeViewportSizeMedium = () => {
-    $(VIEWPORT_SIZE_S_DROPDOWN + " span").removeClass("glyphicon-ok")
-    $(VIEWPORT_SIZE_M_DROPDOWN + " span").removeClass("glyphicon-ok")
-    $(VIEWPORT_SIZE_L_DROPDOWN + " span").removeClass("glyphicon-ok")
-    $(VIEWPORT_SIZE_FIT_DROPDOWN + " span").removeClass("glyphicon-ok")
+    $(VIEWPORT_SIZE_S_DROPDOWN + " span").removeClass("glyphicon-ok");
+    $(VIEWPORT_SIZE_M_DROPDOWN + " span").removeClass("glyphicon-ok");
+    $(VIEWPORT_SIZE_L_DROPDOWN + " span").removeClass("glyphicon-ok");
+    $(VIEWPORT_SIZE_FIT_DROPDOWN + " span").removeClass("glyphicon-ok");
 
     $(VIEWPORT_SIZE_S_SIDEBAR).removeProp("checked");
     $(VIEWPORT_SIZE_M_SIDEBAR).removeProp("checked");
@@ -250,13 +250,13 @@ const synchronizeViewportSizeMedium = () => {
 
     $(VIEWPORT_SIZE_M_SIDEBAR).prop("checked", "checked");
     $(VIEWPORT_SIZE_M_DROPDOWN + " span").addClass("glyphicon-ok");
-}
+};
 
 const synchronizeViewportSizeLarge = () => {
-    $(VIEWPORT_SIZE_S_DROPDOWN + " span").removeClass("glyphicon-ok")
-    $(VIEWPORT_SIZE_M_DROPDOWN + " span").removeClass("glyphicon-ok")
-    $(VIEWPORT_SIZE_L_DROPDOWN + " span").removeClass("glyphicon-ok")
-    $(VIEWPORT_SIZE_FIT_DROPDOWN + " span").removeClass("glyphicon-ok")
+    $(VIEWPORT_SIZE_S_DROPDOWN + " span").removeClass("glyphicon-ok");
+    $(VIEWPORT_SIZE_M_DROPDOWN + " span").removeClass("glyphicon-ok");
+    $(VIEWPORT_SIZE_L_DROPDOWN + " span").removeClass("glyphicon-ok");
+    $(VIEWPORT_SIZE_FIT_DROPDOWN + " span").removeClass("glyphicon-ok");
 
     $(VIEWPORT_SIZE_S_SIDEBAR).removeProp("checked");
     $(VIEWPORT_SIZE_M_SIDEBAR).removeProp("checked");
@@ -264,14 +264,14 @@ const synchronizeViewportSizeLarge = () => {
     $(VIEWPORT_SIZE_FIT_SIDEBAR).removeProp("checked");
 
     $(VIEWPORT_SIZE_L_SIDEBAR).prop("checked", "checked");
-    $(VIEWPORT_SIZE_L_DROPDOWN+ " span").addClass("glyphicon-ok");
-}
+    $(VIEWPORT_SIZE_L_DROPDOWN + " span").addClass("glyphicon-ok");
+};
 
 const synchronizeViewportSizeFit = () => {
-    $(VIEWPORT_SIZE_S_DROPDOWN + " span").removeClass("glyphicon-ok")
-    $(VIEWPORT_SIZE_M_DROPDOWN + " span").removeClass("glyphicon-ok")
-    $(VIEWPORT_SIZE_L_DROPDOWN + " span").removeClass("glyphicon-ok")
-    $(VIEWPORT_SIZE_FIT_DROPDOWN + " span").removeClass("glyphicon-ok")
+    $(VIEWPORT_SIZE_S_DROPDOWN + " span").removeClass("glyphicon-ok");
+    $(VIEWPORT_SIZE_M_DROPDOWN + " span").removeClass("glyphicon-ok");
+    $(VIEWPORT_SIZE_L_DROPDOWN + " span").removeClass("glyphicon-ok");
+    $(VIEWPORT_SIZE_FIT_DROPDOWN + " span").removeClass("glyphicon-ok");
 
     $(VIEWPORT_SIZE_S_SIDEBAR).removeProp("checked");
     $(VIEWPORT_SIZE_M_SIDEBAR).removeProp("checked");
@@ -280,13 +280,15 @@ const synchronizeViewportSizeFit = () => {
 
     $(VIEWPORT_SIZE_FIT_SIDEBAR).prop("checked", "checked");
     $(VIEWPORT_SIZE_FIT_DROPDOWN + " span").addClass("glyphicon-ok");
-}
+};
 
 const updateViewportSize = (currentValue) => {
     // These values are bound to the layout dimensions of the GRNsight website.
     const WIDTH_OFFSET = 250;
     const HEIGHT_OFFSET = 53;
+    const HOST_SITE = "https://dondi.github.io";
     let container = $(".grnsight-container");
+
     // from jquery
     const fitContainer = dimensions => {
         if (container.hasClass(VIEWPORT_FIT)) {
@@ -323,16 +325,16 @@ const updateViewportSize = (currentValue) => {
     }
 
     // Added synchronization
-    if(currentValue === VIEWPORT_S){
-        synchronizeViewportSizeSmall()
-    } else if(currentValue === VIEWPORT_M){
-        synchronizeViewportSizeMedium()
-    } else if(currentValue === VIEWPORT_L){
-        synchronizeViewportSizeLarge()
-    } else if(currentValue === VIEWPORT_FIT){
-        synchronizeViewportSizeFit()
-    } 
-}
+    if (currentValue === VIEWPORT_S) {
+        synchronizeViewportSizeSmall();
+    } else if (currentValue === VIEWPORT_M) {
+        synchronizeViewportSizeMedium();
+    } else if (currentValue === VIEWPORT_L) {
+        synchronizeViewportSizeLarge();
+    } else if (currentValue === VIEWPORT_FIT) {
+        synchronizeViewportSizeFit();
+    }
+};
 
 // Expression DB Access Functions
 const buildTimepointsString = function (selection) {

--- a/web-client/public/js/update-app.js
+++ b/web-client/public/js/update-app.js
@@ -283,7 +283,6 @@ const synchronizeViewportSizeFit = () => {
 }
 
 const updateViewportSize = (currentValue) => {
-    console.log("Hello from update viewport size")
     // These values are bound to the layout dimensions of the GRNsight website.
     const WIDTH_OFFSET = 250;
     const HEIGHT_OFFSET = 53;
@@ -314,7 +313,6 @@ const updateViewportSize = (currentValue) => {
     };
 
     let grnsightContainerClass = `grnsight-container ${currentValue}`;
-    console.log(grnsightContainerClass)
     if (!container.hasClass(currentValue)) {
         container.attr("class", grnsightContainerClass);
         if (currentValue === VIEWPORT_FIT) {
@@ -334,7 +332,6 @@ const updateViewportSize = (currentValue) => {
     } else if(currentValue === VIEWPORT_FIT){
         synchronizeViewportSizeFit()
     } 
-    console.log("Hello")
 }
 
 // Expression DB Access Functions

--- a/web-client/public/js/update-app.js
+++ b/web-client/public/js/update-app.js
@@ -89,8 +89,19 @@ import {
   SPECIES_BUTTON_HUMAN,
   SPECIES_BUTTON_MOUSE,
   SPECIES_BUTTON_NEMATODE,
-  SPECIES_BUTTON_YEAST
-
+  SPECIES_BUTTON_YEAST,
+  VIEWPORT_FIT,
+  VIEWPORT_S,
+  VIEWPORT_M,
+  VIEWPORT_L,
+  VIEWPORT_SIZE_S_DROPDOWN,
+  VIEWPORT_SIZE_M_DROPDOWN,
+  VIEWPORT_SIZE_L_DROPDOWN,
+  VIEWPORT_SIZE_FIT_DROPDOWN,
+  VIEWPORT_SIZE_S_SIDEBAR,
+  VIEWPORT_SIZE_M_SIDEBAR,
+  VIEWPORT_SIZE_L_SIDEBAR,
+  VIEWPORT_SIZE_FIT_SIDEBAR,
 } from "./constants";
 
 // In this transitory state, updateApp might get called before things are completely set up, so for now
@@ -209,6 +220,122 @@ const synchronizeHideAllWeights = () => {
     $(WEIGHTS_SHOW_ALWAYS_CLASS).removeClass("selected");
     $(WEIGHTS_HIDE_CLASS).addClass("selected");
 };
+
+// Viewport
+const synchronizeViewportSizeSmall = () => {
+    $(VIEWPORT_SIZE_S_DROPDOWN + " span").removeClass("glyphicon-ok")
+    $(VIEWPORT_SIZE_M_DROPDOWN + " span").removeClass("glyphicon-ok")
+    $(VIEWPORT_SIZE_L_DROPDOWN + " span").removeClass("glyphicon-ok")
+    $(VIEWPORT_SIZE_FIT_DROPDOWN + " span").removeClass("glyphicon-ok")
+
+    $(VIEWPORT_SIZE_S_SIDEBAR).removeProp("checked");
+    $(VIEWPORT_SIZE_M_SIDEBAR).removeProp("checked");
+    $(VIEWPORT_SIZE_L_SIDEBAR).removeProp("checked");
+    $(VIEWPORT_SIZE_FIT_SIDEBAR).removeProp("checked");
+
+    $(VIEWPORT_SIZE_S_SIDEBAR).prop("checked", "checked");
+    $(VIEWPORT_SIZE_S_DROPDOWN + " span").addClass("glyphicon-ok");
+}
+
+const synchronizeViewportSizeMedium = () => {
+    $(VIEWPORT_SIZE_S_DROPDOWN + " span").removeClass("glyphicon-ok")
+    $(VIEWPORT_SIZE_M_DROPDOWN + " span").removeClass("glyphicon-ok")
+    $(VIEWPORT_SIZE_L_DROPDOWN + " span").removeClass("glyphicon-ok")
+    $(VIEWPORT_SIZE_FIT_DROPDOWN + " span").removeClass("glyphicon-ok")
+
+    $(VIEWPORT_SIZE_S_SIDEBAR).removeProp("checked");
+    $(VIEWPORT_SIZE_M_SIDEBAR).removeProp("checked");
+    $(VIEWPORT_SIZE_L_SIDEBAR).removeProp("checked");
+    $(VIEWPORT_SIZE_FIT_SIDEBAR).removeProp("checked");
+
+    $(VIEWPORT_SIZE_M_SIDEBAR).prop("checked", "checked");
+    $(VIEWPORT_SIZE_M_DROPDOWN + " span").addClass("glyphicon-ok");
+}
+
+const synchronizeViewportSizeLarge = () => {
+    $(VIEWPORT_SIZE_S_DROPDOWN + " span").removeClass("glyphicon-ok")
+    $(VIEWPORT_SIZE_M_DROPDOWN + " span").removeClass("glyphicon-ok")
+    $(VIEWPORT_SIZE_L_DROPDOWN + " span").removeClass("glyphicon-ok")
+    $(VIEWPORT_SIZE_FIT_DROPDOWN + " span").removeClass("glyphicon-ok")
+
+    $(VIEWPORT_SIZE_S_SIDEBAR).removeProp("checked");
+    $(VIEWPORT_SIZE_M_SIDEBAR).removeProp("checked");
+    $(VIEWPORT_SIZE_L_SIDEBAR).removeProp("checked");
+    $(VIEWPORT_SIZE_FIT_SIDEBAR).removeProp("checked");
+
+    $(VIEWPORT_SIZE_L_SIDEBAR).prop("checked", "checked");
+    $(VIEWPORT_SIZE_L_DROPDOWN+ " span").addClass("glyphicon-ok");
+}
+
+const synchronizeViewportSizeFit = () => {
+    $(VIEWPORT_SIZE_S_DROPDOWN + " span").removeClass("glyphicon-ok")
+    $(VIEWPORT_SIZE_M_DROPDOWN + " span").removeClass("glyphicon-ok")
+    $(VIEWPORT_SIZE_L_DROPDOWN + " span").removeClass("glyphicon-ok")
+    $(VIEWPORT_SIZE_FIT_DROPDOWN + " span").removeClass("glyphicon-ok")
+
+    $(VIEWPORT_SIZE_S_SIDEBAR).removeProp("checked");
+    $(VIEWPORT_SIZE_M_SIDEBAR).removeProp("checked");
+    $(VIEWPORT_SIZE_L_SIDEBAR).removeProp("checked");
+    $(VIEWPORT_SIZE_FIT_SIDEBAR).removeProp("checked");
+
+    $(VIEWPORT_SIZE_FIT_SIDEBAR).prop("checked", "checked");
+    $(VIEWPORT_SIZE_FIT_DROPDOWN + " span").addClass("glyphicon-ok");
+}
+
+const updateViewportSize = (currentValue) => {
+    console.log("Hello from update viewport size")
+    // These values are bound to the layout dimensions of the GRNsight website.
+    const WIDTH_OFFSET = 250;
+    const HEIGHT_OFFSET = 53;
+    let container = $(".grnsight-container");
+    // from jquery
+    const fitContainer = dimensions => {
+        if (container.hasClass(VIEWPORT_FIT)) {
+            container.css({
+                width: dimensions.width - WIDTH_OFFSET,
+                height: dimensions.height - HEIGHT_OFFSET
+            });
+        }
+    };
+    const fitContainerToWindow = () => {
+        fitContainer({
+            width: $(window).width(),
+            height: $(window).height()
+        });
+    };
+
+    const requestWindowDimensions = () => {
+        // We send a message if we are in an iframe, and manipulate directly if we aren’t.
+        if (window === window.top) {
+            fitContainerToWindow();
+        } else {
+            window.top.postMessage("dimensions", HOST_SITE);
+        }
+    };
+
+    let grnsightContainerClass = `grnsight-container ${currentValue}`;
+    console.log(grnsightContainerClass)
+    if (!container.hasClass(currentValue)) {
+        container.attr("class", grnsightContainerClass);
+        if (currentValue === VIEWPORT_FIT) {
+            requestWindowDimensions();
+        } else {
+            container.css({ width: "", height: "" });
+        }
+    }
+
+    // Added synchronization
+    if(currentValue === VIEWPORT_S){
+        synchronizeViewportSizeSmall()
+    } else if(currentValue === VIEWPORT_M){
+        synchronizeViewportSizeMedium()
+    } else if(currentValue === VIEWPORT_L){
+        synchronizeViewportSizeLarge()
+    } else if(currentValue === VIEWPORT_FIT){
+        synchronizeViewportSizeFit()
+    } 
+    console.log("Hello")
+}
 
 // Expression DB Access Functions
 const buildTimepointsString = function (selection) {
@@ -648,6 +775,9 @@ export const updateApp = grnState => {
     } else if (grnState.graphLayout === GRID_LAYOUT) {
         updatetoGridLayout();
     }
+
+// Viewport
+    updateViewportSize(grnState.viewportSize);
 
     // Node Coloring
     if (grnState.workbook !== null && grnState.nodeColoring.nodeColoringEnabled

--- a/web-client/views/upload.jade
+++ b/web-client/views/upload.jade
@@ -202,19 +202,19 @@ html
               ul(class='dropdown-menu' role='menu')
                 span(class='menu-subheader') Viewport Size
                 li
-                  a(href='#' id='viewport-size-s' class='viewportOption active')
+                  a(href='#' id='viewport-size-s' class='viewportOption active' value='containerS')
                     span(class='glyphicon')
                     | &nbsp; Small (1104 x 648 pixels)
                 li
-                  a(href='#' id='viewport-size-m' class='viewportOption')
+                  a(href='#' id='viewport-size-m' class='viewportOption' value='containerM')
                     span(class='glyphicon glyphicon-ok')
                     | &nbsp; Medium (1414 x 840 pixels)
                 li
-                  a(href='#' id='viewport-size-l' class='viewportOption')
+                  a(href='#' id='viewport-size-l' class='viewportOption' value='containerL')
                     span(class='glyphicon')
                     | &nbsp; Large (1920 x 1080 pixels)
                 li
-                  a(href='#' id='viewport-size-fit' class='viewportOption')
+                  a(href='#' id='viewport-size-fit' class='viewportOption' value='containerFit')
                     span(class='glyphicon')
                     | &nbsp; Fit To Window
                 li(class='divider')


### PR DESCRIPTION
Fix for #923 by moving logic from `container.js` to new `grnState` model for viewport size control

Pull Request Checklist
- [x] Travis C.I. build passes
- [x] All four Demos look as expected when loaded
- [x] Reload works as expected
- [x] Loading file with Error brings up error modal, and it looks as expected
- [x] Loading file with Warning brings up warnings modal
- [x] Import works for both SIF and GraphML
- [x] Graph can be exported to SIF and GraphML
- [x] Print works as expected
- [x] Restrict graph to viewport works as expected (check/uncheck)
- [x] Viewport Size Changing works as expected (small/medium/large/fit)
- [x] Toggle between Grid Layout and Force Graph Layout works as expected
- [x] Force Graph Parameter Sliders change the number above them and have an effect on the graph
- [x] Locking/Unlocking/Resetting/Undo Resetting the force graph parameters works as expected
- [x] Enabling and disabling node coloring works as expected
- [x] Node coloring options work as expected (selection top/bottom dataset, averaging values, changing max value)
- [x] Weighted graph loaded with the "default to black edges" option checked appears as expected
- [x] Hide/Show Weights works as expected (always/never/upon mouseover)
- [x] Edge Weight Normalization Factor can be changed (set/reset)
- [x] Gray Edge Threshold can be changed, slider changes the number and has an effect on the graph
- [x] Checking Show Gray Edges as Dashed works as expected (check/uncheck)
- [x] D-pad left/right/top/bottom/center works as expected
- [x] Zoom slider changes number and has effect on graph (viewport and menu)
- [x] Right click on a node opens gene page, page is populated with correct data
