### PR TITLE
Issue #1083 D-pad, zoom, and cursor drag now working when graph view restricted to viewport

### DIFF
--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -163,12 +163,14 @@ export var drawGraph = function (workbook) {
         zoomDragPrevX = d3.event.x;
         zoomDragPrevY = d3.event.y;
         $container.removeClass(CURSOR_CLASSES).addClass("cursorGrabbing");
+        // this prevents the zoom from zooming in and out
         if (!adaptive) {
             $container.removeClass(CURSOR_CLASSES);
         }
     };
 
     var zoomDragged = function () {
+        // this only allows the zoom slider to be dragged if adaptive
         if (adaptive) {
             var scale = 1;
             if (zoomContainer.attr("transform")) {
@@ -182,6 +184,7 @@ export var drawGraph = function (workbook) {
     };
 
     var zoomDragEnded = function () {
+        // this only allows the zoom slider to be dragged if adaptive
         $container.removeClass(CURSOR_CLASSES).addClass("cursorGrab");
         if (!adaptive) {
             $container.removeClass(CURSOR_CLASSES);
@@ -243,7 +246,12 @@ export var drawGraph = function (workbook) {
     const setGraphZoom = zoomScale => {
         if (zoomScale < MIDDLE_SCALE) {
             $container.removeClass(CURSOR_CLASSES).addClass("cursorGrab");
-        } else if (!adaptive && zoomScale >= MIDDLE_SCALE) {
+        } // this only allows the zoom slider to be dragged if adaptive -> new code
+        // else if (zoomScale >= MIDDLE_SCALE) {
+        //     $container.removeClass(CURSOR_CLASSES);
+        // }
+        // this prevents the zoom slider to be dragged if not adaptive -> old code
+        else if (!adaptive && zoomScale >= MIDDLE_SCALE) {
             $container.removeClass(CURSOR_CLASSES);
         }
         var container = zoomContainer;
@@ -257,7 +265,7 @@ export var drawGraph = function (workbook) {
     let zoomScaleSliderRight;
 
     const updateAppBasedOnZoomValue = () => {
-
+        // sets constant zoomvalue if not adaptive
         if (!adaptive) {
             grnState.zoomValue = 100.0;
         }
@@ -369,10 +377,12 @@ export var drawGraph = function (workbook) {
             center();
         } else if (fixed) {
             $("#restrict-graph-to-viewport span").addClass("glyphicon-ok");
+            // this checks the box that restricts viewport
             $("input[name=viewport]").prop("checked", "checked");
-            $(document).ready(function () {
-                $(".scale-and-scroll").hide();
-            });
+            // this hides the dpad and the scroll
+            // $(document).ready(function () {
+            //     $(".scale-and-scroll").hide();
+            // });
             adaptive = false;
             $container.removeClass(CURSOR_CLASSES);
             if (grnState.zoomValue > ZOOM_DISPLAY_MIDDLE) {

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -163,7 +163,6 @@ export var drawGraph = function (workbook) {
         zoomDragPrevX = d3.event.x;
         zoomDragPrevY = d3.event.y;
         $container.removeClass(CURSOR_CLASSES).addClass("cursorGrabbing");
-        console.log("zoomDragStarted", $container.attr("class"))
     };
 
     // allows zoom slider to be moved and limits movement when !adaptive
@@ -250,7 +249,7 @@ export var drawGraph = function (workbook) {
     let zoomContainerHeight = 0;
 
     const updateZoomContainerInfo = () => {
-        /* 
+        /*
         * transform attribute of zoomContainer contains translation info about graph
         * we parse through transform attribute of zoomContainer which
             contains information about the scale of the graph */
@@ -270,31 +269,31 @@ export var drawGraph = function (workbook) {
 
         zoomContainerWidth = parseInt(zoomContainer.attr("width"));
         zoomContainerHeight = parseInt(zoomContainer.attr("height"));
-    }
+    };
 
     const inBounds = (width, height) => {
         /*
         * right:  Math.abs(xTranslation + width * graphScale) / zoomContainerWidth <= graphScale - 1.0
         * bottom: Math.abs(yTranslation + height * graphScale) / zoomContainerHeight <= graphScale - 1.0
         * top: y coordinate == -0, left: x coordinate == -0
-        * Amount of movement is dependent on graphScale, so actual movement is not just the width or height 
+        * Amount of movement is dependent on graphScale, so actual movement is not just the width or height
             but width or height multiplied by graphScale
-        * multiply Math.abs(yTranslation + height * graphScale) / zoomContainerHeight by 10 because 
-            decimals like 0.5 are in bounds but decimals like 0.05 or less are out of bounds, then 
+        * multiply Math.abs(yTranslation + height * graphScale) / zoomContainerHeight by 10 because
+            decimals like 0.5 are in bounds but decimals like 0.05 or less are out of bounds, then
             get floor to ensure that decimal does not have 0 in tenths place
         */
-        updateZoomContainerInfo()
+        updateZoomContainerInfo();
 
         return (
             Math.abs(xTranslation + width * graphScale) / zoomContainerWidth <= graphScale - 1.0 &&
             Math.floor((Math.abs(xTranslation + width * graphScale) / zoomContainerWidth) * 10) !== 0 &&
             Math.abs(yTranslation + height * graphScale) / zoomContainerHeight <=
                 graphScale - 1.0 &&
-            Math.floor((Math.abs(yTranslation + height * graphScale) / zoomContainerHeight) * 10) != 0 &&
+            Math.floor((Math.abs(yTranslation + height * graphScale) / zoomContainerHeight) * 10) !== 0 &&
             xTranslation + width <= 0 &&
             yTranslation + height <= 0
         );
-    }
+    };
 
     const setGraphZoom = zoomScale => {
         if (zoomScale < MIDDLE_SCALE) {
@@ -1589,13 +1588,11 @@ export var drawGraph = function (workbook) {
         if (!d3.event.active) {
             simulation.alphaTarget(0.3).restart();
         }
-        
         d.fx = d.x;
         d.fy = d.y;
     }
 
     function dragged (d) {
-        console.log("dragged");
         d.fx = d3.event.x;
         d.fy = d3.event.y;
     }

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -163,6 +163,7 @@ export var drawGraph = function (workbook) {
         zoomDragPrevX = d3.event.x;
         zoomDragPrevY = d3.event.y;
         $container.removeClass(CURSOR_CLASSES).addClass("cursorGrabbing");
+        console.log("zoomDragStarted", $container.attr("class"))
     };
 
     // allows zoom slider to be moved and limits movement when !adaptive
@@ -172,7 +173,7 @@ export var drawGraph = function (workbook) {
             var string = zoomContainer.attr("transform");
             scale = 1 / +(string.match(/scale\(([^\)]+)\)/)[1]);
         }
-        if (!adaptive && d3.event.x >= ZOOM_DISPLAY_MIDDLE) {
+        if (!adaptive && d3.event.x >= ZOOM_DISPLAY_MIDDLE && inBounds(width=5, height=5)) {
             zoom.translateBy(
             zoomContainer,
             scale * (d3.event.x - zoomDragPrevX),
@@ -189,6 +190,7 @@ export var drawGraph = function (workbook) {
         $container.removeClass(CURSOR_CLASSES).addClass("cursorGrab");
     };
 
+    // TODO: this is what keeps track of cursorGrabbing!
     var zoomDrag = d3.drag()
         .on("start", zoomDragStarted)
         .on("drag", zoomDragged)
@@ -212,6 +214,7 @@ export var drawGraph = function (workbook) {
         .scaleExtent([MIN_SCALE, ZOOM_ADAPTIVE_MAX_SCALE])
         .on("zoom", zoomed);
 
+    // this is how we keep track of mousedrags
     svg.style("pointer-events", "all").call(zoomDrag)
         .style("font-family", "sans-serif");
 
@@ -348,26 +351,26 @@ export var drawGraph = function (workbook) {
     }
     
     // Thanks for MutationObserver help from: https://www.seanmcp.com/articles/listen-for-class-change-in-javascript/
-    let lastContainerClassList = $container.attr("class");
-    let mutationCallback2 = null;
-    const cursorDownObserver = new MutationObserver((mutationsList, observer) => {
-        let classList = $container.attr("class")
-        console.log(mutationsList)
-        if (typeof mutationCallback2 === "function") {
-            for (const item of mutationsList) {
-                if (item.attributeName === "class" && classList !== lastContainerClassList) {
-                    // console.log("current list", classList);
-                    // console.log("lastclasslist", lastContainerClassList);
-                    lastContainerClassList = classList;
-                    mutationCallback2();
-                }
-            }
-        }
-    });
+    // let lastContainerClassList = $container.attr("class");
+    // let mutationCallback2 = null;
+    // const cursorDownObserver = new MutationObserver((mutationsList, observer) => {
+    //     let classList = $container.attr("class")
+    //     // console.log(mutationsList)
+    //     if (typeof mutationCallback2 === "function") {
+    //         for (const item of mutationsList) {
+    //             if (item.attributeName === "class" && classList !== lastContainerClassList) {
+    //                 // console.log("current list", classList);
+    //                 // console.log("lastclasslist", lastContainerClassList);
+    //                 lastContainerClassList = classList;
+    //                 mutationCallback2();
+    //             }
+    //         }
+    //     }
+    // });
 
-    mutationCallback2 = boundingBoxListener;
-    cursorDownObserver.disconnect();
-    cursorDownObserver.observe($container.get(0), { attributeFilter: ["class"] });
+    // mutationCallback2 = boundingBoxListener;
+    // cursorDownObserver.disconnect();
+    // cursorDownObserver.observe($container.get(0), { attributeFilter: ["class"] });
 
     const setGraphZoom = zoomScale => {
         if (zoomScale < MIDDLE_SCALE) {

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -159,6 +159,7 @@ export var drawGraph = function (workbook) {
 
     var zoomDragPrevX = 0;
     var zoomDragPrevY = 0;
+
     var zoomDragStarted = function () {
         zoomDragPrevX = d3.event.x;
         zoomDragPrevY = d3.event.y;
@@ -167,22 +168,22 @@ export var drawGraph = function (workbook) {
 
     // allows zoom slider to be moved and limits movement when !adaptive
     var zoomDragged = function () {
-            var scale = 1;
-            if (zoomContainer.attr("transform")) {
-                var string = zoomContainer.attr("transform");
-                scale = 1 / +(string.match(/scale\(([^\)]+)\)/)[1]);
-            }
-            if (!adaptive && d3.event.x >= ZOOM_DISPLAY_MIDDLE) {
-              zoom.translateBy(
-                zoomContainer,
-                scale * (d3.event.x - zoomDragPrevX),
-                scale * (d3.event.y - zoomDragPrevY)
-              );
-            } else if (adaptive) {
-                zoom.translateBy(zoomContainer, scale * (d3.event.x - zoomDragPrevX), scale * (d3.event.y - zoomDragPrevY));
-            }
-            zoomDragPrevX = d3.event.x;
-            zoomDragPrevY = d3.event.y;
+        var scale = 1;
+        if (zoomContainer.attr("transform")) {
+            var string = zoomContainer.attr("transform");
+            scale = 1 / +(string.match(/scale\(([^\)]+)\)/)[1]);
+        }
+        if (!adaptive && d3.event.x >= ZOOM_DISPLAY_MIDDLE) {
+            zoom.translateBy(
+            zoomContainer,
+            scale * (d3.event.x - zoomDragPrevX),
+            scale * (d3.event.y - zoomDragPrevY)
+            );
+        } else if (adaptive) {
+            zoom.translateBy(zoomContainer, scale * (d3.event.x - zoomDragPrevX), scale * (d3.event.y - zoomDragPrevY));
+        }
+        zoomDragPrevX = d3.event.x;
+        zoomDragPrevY = d3.event.y;
     };
 
     var zoomDragEnded = function () {
@@ -236,7 +237,7 @@ export var drawGraph = function (workbook) {
     d3.selectAll(".scrollBtn").on("click", null); // Remove event handlers, if there were any.
     var arrowMovement = [ "Up", "Left", "Right", "Down" ];
     arrowMovement.forEach(function (direction) {
-        d3.select(".scroll" + direction).on("click", function() {
+        d3.select(".scroll" + direction).on("click", function () {
             move(direction.toLowerCase());
         });
     });
@@ -259,7 +260,7 @@ export var drawGraph = function (workbook) {
     const updateAppBasedOnZoomValue = () => {
         // If !adaptive, set Zoomvalue to ZOOM_DISPLAY_MIDDLE, 100, so do not zoom outside Ggr
         if (!adaptive && grnState.zoomValue < ZOOM_DISPLAY_MIDDLE) {
-          grnState.zoomValue = ZOOM_DISPLAY_MIDDLE;
+            grnState.zoomValue = ZOOM_DISPLAY_MIDDLE;
         }
 
         const zoomDisplay = grnState.zoomValue;
@@ -269,7 +270,7 @@ export var drawGraph = function (workbook) {
                 ? zoomScaleLeft
                 : zoomScaleRight)(zoomDisplay)
             );
-        } else if (!adaptive && grnState.zoomValue >= ZOOM_DISPLAY_MIDDLE){
+        } else if (!adaptive && grnState.zoomValue >= ZOOM_DISPLAY_MIDDLE) {
             setGraphZoom(
                 (zoomDisplay <= ZOOM_DISPLAY_MIDDLE
                 ? zoomScaleLeft
@@ -386,9 +387,6 @@ export var drawGraph = function (workbook) {
     var restrictGraphToViewport = function (fixed) {
         if (!fixed) {
             $("#restrict-graph-to-viewport span").removeClass("glyphicon-ok");
-            $(document).ready(function () {
-                $(".scale-and-scroll").show();
-            });
             $("input[name=viewport]").removeProp("checked");
             $container.addClass("cursorGrabbing");
             adaptive = true;
@@ -397,14 +395,15 @@ export var drawGraph = function (workbook) {
         } else if (fixed) {
             $("#restrict-graph-to-viewport span").addClass("glyphicon-ok");
             $("input[name=viewport]").prop("checked", "checked");
+            // $(document).ready(function() {
+            //     $(".scale-and-scroll").hide();
+            // });
             adaptive = false;
             $container.removeClass(CURSOR_CLASSES);
-            $container.removeClass("cursorGrab");
             if (grnState.zoomValue > ZOOM_DISPLAY_MIDDLE) {
                 grnState.zoomValue = ZOOM_DISPLAY_MIDDLE;
                 updateAppBasedOnZoomValue();
                 $container.removeClass(CURSOR_CLASSES);
-                $container.removeClass("cursorGrabbing");
             }
             width = $container.width();
             height = $container.height();
@@ -441,9 +440,11 @@ export var drawGraph = function (workbook) {
             direction === "up" ? -50 : direction === "down" ? 50 : 0;
 
         if (adaptive) {
-          zoom.translateBy(zoomContainer, width, height);
-        } else if (!adaptive && grnState.zoomValue != ZOOM_DISPLAY_MIDDLE) {
-          // we parse through transform attribute of zoomContainer which contains information about the scale of the graph
+            zoom.translateBy(zoomContainer, width, height);
+        } else if (!adaptive && grnState.zoomValue !== ZOOM_DISPLAY_MIDDLE) {
+          /* transform attribute of zoomContainer contains translation info about graph */
+                    /* we parse through transform attribute of zoomContainer which
+          contains information about the scale of the graph */
             const graphScale = parseFloat(
               zoomContainer
               .attr("transform")
@@ -452,30 +453,78 @@ export var drawGraph = function (workbook) {
 
             const xTranslation = parseFloat(zoomContainer
               .attr("transform")
-              .split("(")[1].split(",")[0])
+              .split("(")[1].split(",")[0]);
 
             const yTranslation = parseFloat(zoomContainer
               .attr("transform")
-              .split("(")[1].split(",")[1].split(")")[0])
+              .split("(")[1].split(",")[1].split(")")[0]);
 
             const zoomContainerWidth = parseInt(zoomContainer.attr("width"));
             const zoomContainerHeight = parseInt(zoomContainer.attr("height"));
+            console.log(" ")
+            console.log("graphScale", graphScale)
+            /* 
+            "new translation",
+            width + xTranslation + zoomContainerWidth,
             
-            // right: abs(new x coordinate) / zoomContainerWidth - 1.0 == all digits after decimal point if graphscale > 1 and < 2 or graphScale - 1 if graphScale >= 2
-            // bottom: abs(new y coordinate) / zoomContainerHeight - 1.0 == all digits after decimal point if graphscale > 1 and < 2 or graphScale - 1 if graphScale >= 2
-            // top: y coordinate rounded == -0
-            // left: y coordinate rounded == -0
+            "height + yTranslation",
+            height + yTranslation + zoomContainerHidth,
+            */
+            console.log(
+              "width",
+              zoomContainerWidth,
+              "xTranslation",
+              xTranslation,
+              "movement width",
+              width * graphScale,
+              "test for new width move",
+              Math.abs(xTranslation + width * graphScale) / zoomContainerWidth
+            );
+            console.log("height",
+              zoomContainerHeight,
+              "yTranslation",
+              yTranslation,
+              "movement height",
+              height * graphScale, 
+              "total new height translation",
+              height + yTranslation + zoomContainerHeight,
+              "test for new y move",
+              Math.abs(yTranslation + height * graphScale) / zoomContainerHeight
+            );
+            // make sure new position within bounds of graph
+            //TODO: tried multiplying width by graphScale?
+            // const newWidth = width * graphScale + xTranslation + zoomContainerWidth <= zoomContainerWidth;
+            // const newHeight = height * graphScale + yTranslation + zoomContainerHeight <= zoomContainerHeight
+
+            // if (0 <= newWidth && zoomContainerWidth >= newWidth && 0 <= newHeight && zoomContainerHeight >= newHeight) {
+            //   zoom.translateBy(zoomContainer, width, height);
+            // }
+
+            /*
+            * right: abs(new x coordinate) / zoomContainerWidth - 1.0 == all digits after decimal point if
+                graphscale > 1 and < 2 or graphScale - 1 if graphScale >= 2
+            * bottom: abs(new y coordinate) / zoomContainerHeight - 1.0 == all digits after decimal point if
+                graphscale > 1 and < 2 or graphScale - 1 if graphScale >= 2
+            * top: y coordinate rounded == -0
+            * left: y coordinate rounded == -0
+            * Amount of movement is dependent on graphScale, so actual movement is not just the width or height 
+                but width or height multiplied by graphScale
+            * multiply Math.abs(yTranslation + height * graphScale) / zoomContainerHeight by 10 because 
+                decimals like 0.5 are in bounds but decimals like 0.05 are out of bounds
+            */
             if (
-                Math.abs(xTranslation + width) / zoomContainerWidth <=
+                Math.abs(xTranslation + width * graphScale) / zoomContainerWidth <=
                     graphScale - 1.0 &&
-                Math.abs(yTranslation + height) / zoomContainerHeight <=
+                Math.floor(Math.abs(xTranslation + width * graphScale) / zoomContainerWidth * 10 ) !== 0 &&
+                Math.abs(yTranslation + height * graphScale) / zoomContainerHeight <=
                     graphScale - 1.0 &&
+                Math.floor(Math.abs(yTranslation + height * graphScale) / zoomContainerHeight * 10) != 0 &&
                 xTranslation + width <= 0 &&
                 yTranslation + height <= 0
             ) {
                 zoom.translateBy(zoomContainer, width, height);
             }
-        } 
+        }
     }
 
     var defs = boundingBoxContainer.append("defs");
@@ -1433,15 +1482,15 @@ export var drawGraph = function (workbook) {
                         height += OFFSET_VALUE;
                         boundingBoxContainer.attr("height", height);
                         link
-                        .attr("y1", function(d) {
+                        .attr("y1", function (d) {
                             return d.source.y;
                         })
-                        .attr("y2", function(d) {
+                        .attr("y2", function (d) {
                             return d.target.y;
                         });
 
-                        node.attr("y", function(d) {
-                        return d.y;
+                        node.attr("y", function (d) {
+                            return d.y;
                         });
                     }
                 }

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -195,8 +195,6 @@ export var drawGraph = function (workbook) {
             zoomDragPrevX = d3.event.x;
             zoomDragPrevY = d3.event.y;
             }
-            
-            
         }
     };
 
@@ -263,13 +261,6 @@ export var drawGraph = function (workbook) {
     const setGraphZoom = zoomScale => {
         if (zoomScale < MIDDLE_SCALE) {
             $container.removeClass(CURSOR_CLASSES).addClass("cursorGrab");
-        } // this only allows the zoom slider to be dragged if adaptive -> new code
-        // else if (zoomScale >= MIDDLE_SCALE) {
-        //     $container.removeClass(CURSOR_CLASSES);
-        // }
-        // this prevents the zoom slider to be dragged if not adaptive -> old code
-        else if (!adaptive && zoomScale >= MIDDLE_SCALE) {
-            $container.removeClass(CURSOR_CLASSES);
         }
         var container = zoomContainer;
         zoom.scaleTo(container, zoomScale);
@@ -282,10 +273,10 @@ export var drawGraph = function (workbook) {
     let zoomScaleSliderRight;
 
     const updateAppBasedOnZoomValue = () => {
-        // TODO: sets constant zoomvalue if not adaptive. This is the line that keeps it constant
-        // if (!adaptive) {
-        //     grnState.zoomValue = 100.0;
-        // }
+        // If !adaptive, set Zoomvalue to ZOOM_DISPLAY_MIDDLE, 100, so do not zoom outside Ggr
+        if (!adaptive && grnState.zoomValue < ZOOM_DISPLAY_MIDDLE) {
+          grnState.zoomValue = ZOOM_DISPLAY_MIDDLE;
+        }
 
         const zoomDisplay = grnState.zoomValue;
         if (adaptive) {
@@ -294,14 +285,12 @@ export var drawGraph = function (workbook) {
                 ? zoomScaleLeft
                 : zoomScaleRight)(zoomDisplay)
             );
-        } else {
-            if (grnState.zoomValue >= ZOOM_DISPLAY_MIDDLE) {
-                setGraphZoom(
-                  (zoomDisplay <= ZOOM_DISPLAY_MIDDLE
-                    ? zoomScaleLeft
-                    : zoomScaleRight)(zoomDisplay)
-                );
-            } 
+        } else if (!adaptive && grnState.zoomValue >= ZOOM_DISPLAY_MIDDLE){
+            setGraphZoom(
+                (zoomDisplay <= ZOOM_DISPLAY_MIDDLE
+                ? zoomScaleLeft
+                : zoomScaleRight)(zoomDisplay)
+            );
         }
 
         const finalDisplay = grnState.zoomValue;
@@ -314,8 +303,22 @@ export var drawGraph = function (workbook) {
             $(ZOOM_INPUT).val(finalDisplay);
         }
 
-        $(ZOOM_SLIDER).val((finalDisplay <= ZOOM_DISPLAY_MIDDLE ? zoomScaleSliderLeft : zoomScaleSliderRight)
-            .invert(finalDisplay));
+        if (adaptive) {
+            $(ZOOM_SLIDER).val(
+              (finalDisplay <= ZOOM_DISPLAY_MIDDLE
+                ? zoomScaleSliderLeft
+                : zoomScaleSliderRight
+              ).invert(finalDisplay)
+            );
+        } else if (!adaptive && grnState.zoomValue >= ZOOM_DISPLAY_MIDDLE) {
+            // only allow minimum zoom value to be 100% so that do not go outside of viewport
+            $(ZOOM_SLIDER).val(
+            (finalDisplay <= ZOOM_DISPLAY_MIDDLE
+                ? zoomScaleSliderLeft
+                : zoomScaleSliderRight
+            ).invert(finalDisplay)
+            );
+        }
     };
 
     /**

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -481,15 +481,22 @@ export var drawGraph = function (workbook) {
 
     // move: moves graph with D-pad
     function move (direction) {
-        var width =
-            direction === "left" ? -50 : direction === "right" ? 50 : 0;
-        var height =
-            direction === "up" ? -50 : direction === "down" ? 50 : 0;
-
+        var width = direction === "left" ? -50 : direction === "right" ? 50 : 0;
+        var height = direction === "up" ? -50 : direction === "down" ? 50 : 0;
         if (adaptive) {
             zoom.translateBy(zoomContainer, width, height);
-        } else if (!adaptive && grnState.zoomValue !== ZOOM_DISPLAY_MIDDLE && inBounds(width, height)) {
-            zoom.translateBy(zoomContainer, width, height);
+        } else if (!adaptive && grnState.zoomValue !== ZOOM_DISPLAY_MIDDLE) {
+            if (inBounds(width, height)) {
+                zoom.translateBy(zoomContainer, width, height);
+            } else if (inBounds(0, 0)) {
+                // ^check if current position in bounds but still not at border,
+                // then move remaining amount left in graph
+                if (width !== 0 && inBounds(width / graphZoom / 3, height)) {
+                    zoom.translateBy(zoomContainer, width / graphZoom / 3, height);
+                } else if (height !== 0 && inBounds(width, height / graphZoom / 3)) {
+                    zoom.translateBy(zoomContainer, width, height / graphZoom / 3);
+                }
+            }
         }
     }
 

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -411,12 +411,7 @@ export var drawGraph = function (workbook) {
             center();
         } else if (fixed) {
             $("#restrict-graph-to-viewport span").addClass("glyphicon-ok");
-            // this checks the box that restricts viewport
             $("input[name=viewport]").prop("checked", "checked");
-            // this hides the dpad and the scroll
-            // $(document).ready(function () {
-            //     $(".scale-and-scroll").hide();
-            // });
             adaptive = false;
             $container.removeClass(CURSOR_CLASSES);
             if (grnState.zoomValue > ZOOM_DISPLAY_MIDDLE) {

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -283,22 +283,48 @@ export var drawGraph = function (workbook) {
             get floor to ensure that decimal does not have 0 in tenths place
         */
         updateZoomContainerInfo()
+        console.log("inBounds function ran")
+        if (width == 0 && height == 0) {
+            console.log("width and height change = 0")
+            
+            // console.log("in bounds?",
+            //   Math.abs(xTranslation) / zoomContainerWidth <= graphScale - 1.0 &&
+            //     Math.floor(
+            //       (Math.abs(xTranslation) / zoomContainerWidth) * 10
+            //     ) !== 0 &&
+            //     Math.abs(yTranslation) / zoomContainerHeight <=
+            //       graphScale - 1.0 &&
+            //     Math.floor(
+            //       (Math.abs(yTranslation) / zoomContainerHeight) * 10
+            //     ) != 0 &&
+            //     xTranslation + width <= 0 &&
+            //     yTranslation + height <= 0
+            // );
+            return (
+                Math.abs(xTranslation) / zoomContainerWidth <= graphScale - 1.0 &&
+                Math.floor((Math.abs(xTranslation) / zoomContainerWidth) * 10) !== 0 &&
+                Math.abs(yTranslation) / zoomContainerHeight <= graphScale - 1.0 &&
+                Math.floor((Math.abs(yTranslation) / zoomContainerHeight) * 10) != 0 &&
+                xTranslation + width <= 0 &&
+                yTranslation + height <= 0)
+            
+        }
         
         return (
-          Math.abs(xTranslation + width * graphScale) / zoomContainerWidth <= graphScale - 1.0 &&
-          Math.floor((Math.abs(xTranslation + width * graphScale) / zoomContainerWidth) * 10) !== 0 &&
-          Math.abs(yTranslation + height * graphScale) / zoomContainerHeight <=
-            graphScale - 1.0 &&
-          Math.floor((Math.abs(yTranslation + height * graphScale) / zoomContainerHeight) * 10) != 0 &&
-          xTranslation + width <= 0 &&
-          yTranslation + height <= 0
+            Math.abs(xTranslation + width * graphScale) / zoomContainerWidth <= graphScale - 1.0 &&
+            Math.floor((Math.abs(xTranslation + width * graphScale) / zoomContainerWidth) * 10) !== 0 &&
+            Math.abs(yTranslation + height * graphScale) / zoomContainerHeight <=
+                graphScale - 1.0 &&
+            Math.floor((Math.abs(yTranslation + height * graphScale) / zoomContainerHeight) * 10) != 0 &&
+            xTranslation + width <= 0 &&
+            yTranslation + height <= 0
         );
     }
 
     const boundingBoxListener = () => {
         console.log("boundingBox mousedown");
         // TODO: change to !adaptive only, || adaptive for testing
-        if (!adaptive || adaptive && !inBounds(width=0, height=0)) {
+        if (!adaptive && !inBounds(width=0, height=0)) {
             /*
                 * stack overflow combine mouseover and mousemove: 
                 https://stackoverflow.com/questions/55987499/prevent-panning-outside-of-map-bounds-in-d3v5
@@ -320,8 +346,7 @@ export var drawGraph = function (workbook) {
             //     "translate(" + [tx, ty] + ")",
             //     "scale(" + scale + ")",
             //   ].join(" ")
-            // );
-            console.log("not in bounds")
+            // )
         } 
         // console.log(tx, ty)
         // console.log("e event info", e.x, e.y, e.scale, e.k)

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -172,12 +172,26 @@ export var drawGraph = function (workbook) {
             var string = zoomContainer.attr("transform");
             scale = 1 / +(string.match(/scale\(([^\)]+)\)/)[1]);
         }
-        if (!adaptive && d3.event.x >= ZOOM_DISPLAY_MIDDLE && inBounds(d3.event.dx, d3.event.dy)) {
-            zoom.translateBy(
-                zoomContainer,
-                scale * (d3.event.x - zoomDragPrevX),
-                scale * (d3.event.y - zoomDragPrevY)
-            );
+        if (!adaptive && d3.event.x >= ZOOM_DISPLAY_MIDDLE ) {
+            if (
+              inBounds(d3.event.dx, d3.event.dy) ||
+              inBounds(d3.event.x * graphScale, d3.event.x * graphScale)
+            ) {
+                // zoom.translateExtent([0,0], [zoomContainerWidth, zoomContainerHeight])
+                zoom.translateBy(
+                    zoomContainer,
+                    scale * (d3.event.x - zoomDragPrevX),
+                    scale * (d3.event.y - zoomDragPrevY)
+                );
+            }
+            // } else if (!inBounds(d3.event.x * graphScale, d3.event.x * graphScale)) {
+            //     console.log(d3.event)
+            //     zoom.translateBy(
+            //         zoomContainer,
+            //         scale * (d3.event.x - zoomDragPrevX),
+            //         scale * (d3.event.y - zoomDragPrevY)
+            //     );
+            // }
         } else if (adaptive) {
             zoom.translateBy(zoomContainer, scale * (d3.event.x - zoomDragPrevX), scale * (d3.event.y - zoomDragPrevY));
         }
@@ -267,8 +281,6 @@ export var drawGraph = function (workbook) {
             .attr("transform")
             .split("(")[1].split(",")[1].split(")")[0]);
 
-        zoomContainerWidth = parseInt(zoomContainer.attr("width"));
-        zoomContainerHeight = parseInt(zoomContainer.attr("height"));
     };
 
     const inBounds = (width, height) => {
@@ -284,14 +296,44 @@ export var drawGraph = function (workbook) {
         */
         updateZoomContainerInfo();
 
-        return (
-            Math.abs(xTranslation + width * graphScale) / zoomContainerWidth <= graphScale - 1.0 &&
-            Math.floor((Math.abs(xTranslation + width * graphScale) / zoomContainerWidth) * 10) !== 0 &&
-            Math.abs(yTranslation + height * graphScale) / zoomContainerHeight <=
-                graphScale - 1.0 &&
-            Math.floor((Math.abs(yTranslation + height * graphScale) / zoomContainerHeight) * 10) !== 0 &&
+        console.log(
+          Math.abs(xTranslation + width * graphScale) / zoomContainerWidth <=
+            graphScale - 1.0 &&
+            Math.floor(
+              (Math.abs(xTranslation + width * graphScale) /
+                zoomContainerWidth) *
+                10
+            ) !== 0 &&
+            Math.abs(yTranslation + height * graphScale) /
+              zoomContainerHeight <=
+              graphScale - 1.0 &&
+            Math.floor(
+              (Math.abs(yTranslation + height * graphScale) /
+                zoomContainerHeight) *
+                10
+            ) !== 0 &&
             xTranslation + width <= 0 &&
             yTranslation + height <= 0
+        );
+
+        // console.log($container.width(), $container.height(), zoomContainerWidth, zoomContainerHeight)
+
+        return (
+          Math.abs(xTranslation + width * graphScale) / $container.width() <=
+            graphScale - 1.0 &&
+          Math.floor(
+            (Math.abs(xTranslation + width * graphScale) / $container.width()) *
+              10
+          ) !== 0 &&
+          Math.abs(yTranslation + height * graphScale) / $container.height() <=
+            graphScale - 1.0 &&
+          Math.floor(
+            (Math.abs(yTranslation + height * graphScale) /
+              $container.height()) *
+              10
+          ) !== 0 &&
+          xTranslation + width * graphScale <= 0 &&
+          yTranslation + height * graphScale <= 0
         );
     };
 
@@ -490,10 +532,8 @@ export var drawGraph = function (workbook) {
 
         if (adaptive) {
             zoom.translateBy(zoomContainer, width, height);
-        } else if (!adaptive && grnState.zoomValue !== ZOOM_DISPLAY_MIDDLE) {
-            if (inBounds(width, height)) {
-                zoom.translateBy(zoomContainer, width, height);
-            }
+        } else if (!adaptive && grnState.zoomValue !== ZOOM_DISPLAY_MIDDLE && inBounds(width, height)) {
+            zoom.translateBy(zoomContainer, width, height);
         }
     }
 

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -442,9 +442,10 @@ export var drawGraph = function (workbook) {
         if (adaptive) {
             zoom.translateBy(zoomContainer, width, height);
         } else if (!adaptive && grnState.zoomValue !== ZOOM_DISPLAY_MIDDLE) {
-          /* transform attribute of zoomContainer contains translation info about graph */
-                    /* we parse through transform attribute of zoomContainer which
-          contains information about the scale of the graph */
+            /* 
+            * transform attribute of zoomContainer contains translation info about graph
+            * we parse through transform attribute of zoomContainer which
+                contains information about the scale of the graph */
             const graphScale = parseFloat(
               zoomContainer
               .attr("transform")
@@ -461,44 +462,6 @@ export var drawGraph = function (workbook) {
 
             const zoomContainerWidth = parseInt(zoomContainer.attr("width"));
             const zoomContainerHeight = parseInt(zoomContainer.attr("height"));
-            console.log(" ")
-            console.log("graphScale", graphScale)
-            /* 
-            "new translation",
-            width + xTranslation + zoomContainerWidth,
-            
-            "height + yTranslation",
-            height + yTranslation + zoomContainerHidth,
-            */
-            console.log(
-              "width",
-              zoomContainerWidth,
-              "xTranslation",
-              xTranslation,
-              "movement width",
-              width * graphScale,
-              "test for new width move",
-              Math.abs(xTranslation + width * graphScale) / zoomContainerWidth
-            );
-            console.log("height",
-              zoomContainerHeight,
-              "yTranslation",
-              yTranslation,
-              "movement height",
-              height * graphScale, 
-              "total new height translation",
-              height + yTranslation + zoomContainerHeight,
-              "test for new y move",
-              Math.abs(yTranslation + height * graphScale) / zoomContainerHeight
-            );
-            // make sure new position within bounds of graph
-            //TODO: tried multiplying width by graphScale?
-            // const newWidth = width * graphScale + xTranslation + zoomContainerWidth <= zoomContainerWidth;
-            // const newHeight = height * graphScale + yTranslation + zoomContainerHeight <= zoomContainerHeight
-
-            // if (0 <= newWidth && zoomContainerWidth >= newWidth && 0 <= newHeight && zoomContainerHeight >= newHeight) {
-            //   zoom.translateBy(zoomContainer, width, height);
-            // }
 
             /*
             * right: abs(new x coordinate) / zoomContainerWidth - 1.0 == all digits after decimal point if

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -164,9 +164,9 @@ export var drawGraph = function (workbook) {
         zoomDragPrevY = d3.event.y;
         $container.removeClass(CURSOR_CLASSES).addClass("cursorGrabbing");
         // this prevents the zoom from zooming in and out
-        if (!adaptive) {
-            $container.removeClass(CURSOR_CLASSES);
-        }
+        // if (!adaptive) {
+        //     $container.removeClass(CURSOR_CLASSES);
+        // }
     };
 
     var zoomDragged = function () {
@@ -180,15 +180,32 @@ export var drawGraph = function (workbook) {
             zoom.translateBy(zoomContainer, scale * (d3.event.x - zoomDragPrevX), scale * (d3.event.y - zoomDragPrevY));
             zoomDragPrevX = d3.event.x;
             zoomDragPrevY = d3.event.y;
+        } else {
+            var scale = 1;
+            if (zoomContainer.attr("transform")) {
+              var string = zoomContainer.attr("transform");
+              scale = 1 / +string.match(/scale\(([^\)]+)\)/)[1];
+            }
+            if (d3.event.x >= ZOOM_DISPLAY_MIDDLE) {
+                zoom.translateBy(
+                    zoomContainer,
+                    scale * (d3.event.x - zoomDragPrevX),
+                    scale * (d3.event.y - zoomDragPrevY)
+                );
+            zoomDragPrevX = d3.event.x;
+            zoomDragPrevY = d3.event.y;
+            }
+            
+            
         }
     };
 
     var zoomDragEnded = function () {
         // this only allows the zoom slider to be dragged if adaptive
         $container.removeClass(CURSOR_CLASSES).addClass("cursorGrab");
-        if (!adaptive) {
-            $container.removeClass(CURSOR_CLASSES);
-        }
+        // if (!adaptive) {
+        //     $container.removeClass(CURSOR_CLASSES);
+        // }
     };
 
     var zoomDrag = d3.drag()
@@ -265,13 +282,27 @@ export var drawGraph = function (workbook) {
     let zoomScaleSliderRight;
 
     const updateAppBasedOnZoomValue = () => {
-        // sets constant zoomvalue if not adaptive
-        if (!adaptive) {
-            grnState.zoomValue = 100.0;
-        }
+        // TODO: sets constant zoomvalue if not adaptive. This is the line that keeps it constant
+        // if (!adaptive) {
+        //     grnState.zoomValue = 100.0;
+        // }
 
         const zoomDisplay = grnState.zoomValue;
-        setGraphZoom((zoomDisplay <= ZOOM_DISPLAY_MIDDLE ? zoomScaleLeft : zoomScaleRight)(zoomDisplay));
+        if (adaptive) {
+            setGraphZoom(
+                (zoomDisplay <= ZOOM_DISPLAY_MIDDLE
+                ? zoomScaleLeft
+                : zoomScaleRight)(zoomDisplay)
+            );
+        } else {
+            if (grnState.zoomValue >= ZOOM_DISPLAY_MIDDLE) {
+                setGraphZoom(
+                  (zoomDisplay <= ZOOM_DISPLAY_MIDDLE
+                    ? zoomScaleLeft
+                    : zoomScaleRight)(zoomDisplay)
+                );
+            } 
+        }
 
         const finalDisplay = grnState.zoomValue;
         $(ZOOM_PERCENT).text(`${finalDisplay}%`);


### PR DESCRIPTION
D-pad, zoom, and cursor drag now enabled and limited to viewport when restrict to viewport checked.

Pull Request Checklist
- [x] Travis C.I. build passes
- [x] All five Demos look as expected when loaded
- [x] Reload works as expected
- [x] Loading file with Error brings up error modal, and it looks as expected
- [x] Loading file with Warning brings up warnings modal
- [x] Loading a network from the database looks as expected when loaded
- [x] Import works for both SIF and GraphML
- [x] Graph can be exported to SIF, GraphML and Excel
- [ ] Graph can be exported to PNG, SVG and PDF
- [x] Expression data and Additional Sheets can be exported to Excel
- [x] Print works as expected
- [x] Restrict graph to viewport works as expected (check/uncheck)
- [x] Viewport Size Changing works as expected (small/medium/large/fit)
- [x] Toggle between Grid Layout and Force Graph Layout works as expected
- [x] Force Graph Parameter Sliders change the number above them and have an effect on the graph
- [x] Locking/Unlocking/Resetting/Undo Resetting the force graph parameters works as expected
- [x] Enabling and disabling node coloring works as expected
- [x] Node coloring options work as expected (selection top/bottom dataset, averaging values, changing max value)
- [x] Weighted graph loaded with the "Enable Edge Coloring" option checked appears as expected
- [x] Hide/Show Weights works as expected (always/never/upon mouseover)
- [x] Edge Weight Normalization Factor can be changed (set/reset)
- [x] Gray Edge Threshold can be changed, slider changes the number and has an effect on the graph
- [x] Checking Show Gray Edges as Dashed works as expected (check/uncheck)
- [x] D-pad left/right/top/bottom/center works as expected
- [x] Zoom slider changes number and has effect on graph (viewport and menu)
- [x] Right click on a node opens gene page, page is populated with correct data