### PR TITLE
Fixing the network mode for export function #1079

### DIFF
--- a/server/controllers/exporters/sif.js
+++ b/server/controllers/exporters/sif.js
@@ -8,7 +8,7 @@ var exportEdges = function (workbook, gene, geneIndex) {
             result += [
                 gene.name,
                 workbook.sheetType === constants.WEIGHTED ?
-                    link.value : workbook.workbookType === "protein-protein-physical-interactions" ?
+                    link.value : workbook.workbookType === "protein-protein-physical-interaction" ?
                     "pp" : "pd",
                 workbook.genes[link.target].name
             ].join("\t") + "\n";

--- a/server/controllers/network-sheet-parser.js
+++ b/server/controllers/network-sheet-parser.js
@@ -299,7 +299,7 @@ var parseNetworkSheet = function (sheet, network) {
 */
 
 exports.workbookType = function (workbookFile) {
-    let workbookType = "grn";
+    let workbookType;
     for (const sheet of workbookFile) {
         if (sheet.name.toLowerCase() === "network") {
             const cellA1 = sheet.data[0][0];


### PR DESCRIPTION
Originally, the network mode for ppi was mistyped. I was protein-protein-physical-interactions but should be protien-protein-physical-interaction. This is issue #1079 

Pull Request Checklist
- [x] Travis C.I. build passes
- [x] All five Demos look as expected when loaded
- [x] Reload works as expected
- [x] Loading file with Error brings up error modal, and it looks as expected
- [x] Loading file with Warning brings up warnings modal
- [x] Loading a network from the database looks as expected when loaded
- [x] Import works for both SIF and GraphML
- [x] Graph can be exported to SIF, GraphML and Excel
- [x] Graph can be exported to PNG, SVG and PDF
- [x] Expression data and Additional Sheets can be exported to Excel
- [x] Print works as expected
- [x] Restrict graph to viewport works as expected (check/uncheck)
- [x] Viewport Size Changing works as expected (small/medium/large/fit)
- [x] Toggle between Grid Layout and Force Graph Layout works as expected
- [x] Force Graph Parameter Sliders change the number above them and have an effect on the graph
- [x] Locking/Unlocking/Resetting/Undo Resetting the force graph parameters works as expected
- [x] Enabling and disabling node coloring works as expected
- [x] Node coloring options work as expected (selection top/bottom dataset, averaging values, changing max value)
- [x] Weighted graph loaded with the "Enable Edge Coloring" option checked appears as expected
- [x] Hide/Show Weights works as expected (always/never/upon mouseover)
- [x] Edge Weight Normalization Factor can be changed (set/reset)
- [x] Gray Edge Threshold can be changed, slider changes the number and has an effect on the graph
- [x] Checking Show Gray Edges as Dashed works as expected (check/uncheck)
- [x] D-pad left/right/top/bottom/center works as expected
- [x] Zoom slider changes number and has effect on graph (viewport and menu)
- [x] Right click on a node opens gene page, page is populated with correct data
