### PR TITLE
Renamed cell A1 named for protein protein interaction network mode #1054

### DIFF
--- a/server/controllers/constants.js
+++ b/server/controllers/constants.js
@@ -4,6 +4,8 @@ module.exports = {
     NOT_FOUND: -1,
     WEIGHTED: "weighted",
     UNWEIGHTED: "unweighted",
+    CELL_A1_PPI: "cols protein1/ rows protein2",
+    CELL_A1_GRN: "cols regulators/rows targets",
 
     GRNSIGHT_FILENAME_HEADER: "X-GRNsight-Filename",
 

--- a/server/controllers/export-constants.js
+++ b/server/controllers/export-constants.js
@@ -37,8 +37,9 @@ module.exports = {
             warningCode: "INCORRECT_NETWORK_SHEET_EXPORT_WARNING",
             errorDescription: "GRNsight has detected that the 'network' sheet or the 'network_optimized_weights'" +
                 " sheet is improperly formattedPlease look over your exported workbook and ensure that network" +
-                " sheets have cell A1 as 'cols regulators/rows targets' exactly, and all gene are using the  naming" +
-                " conventions listed at: \nhttps://dondi.github.io/GRNsight/documentation.html."
+                " sheets have cell A1 as 'cols regulators/rows targets' or 'cols protein1/ rows protein2' exactly" +
+                " and all gene are using the  naming conventions listed at:" +
+                " \nhttps://dondi.github.io/GRNsight/documentation.html."
         },
         // Missing Source Genes
         MISSING_SOURCE_GENES_EXPORT_WARNING: {

--- a/server/controllers/exporters/xlsx.js
+++ b/server/controllers/exporters/xlsx.js
@@ -21,7 +21,7 @@ const buildNetworkSheet = function (genes, links, workbookType) {
     if (workbookType === "grn") {
         geneNameArray.unshift("cols regulators/rows targets");
     } else {
-        geneNameArray.unshift("protein 1/protein 2");
+        geneNameArray.unshift("cols protein1/ rows protein2");
     }
 
     links.forEach((link) => {

--- a/server/controllers/exporters/xlsx.js
+++ b/server/controllers/exporters/xlsx.js
@@ -1,5 +1,6 @@
 // const { meta } = require("eslint/lib/rules/*");
 const xlsx = require("node-xlsx");
+const { CELL_A1_GRN, CELL_A1_PPI } = require("../constants");
 
 const buildGeneNameArray = function (genes) {
     const geneNameArray = genes.map(gene => gene["name"]);
@@ -19,9 +20,9 @@ const buildNetworkSheet = function (genes, links, workbookType) {
     // EX: ["CIN5", 0, 0, 1]
     Object.keys(geneNameArray).forEach(index => networkSheet[index][0] = geneNameArray[index]);
     if (workbookType === "grn") {
-        geneNameArray.unshift("cols regulators/rows targets");
+        geneNameArray.unshift(CELL_A1_GRN);
     } else {
-        geneNameArray.unshift("cols protein1/ rows protein2");
+        geneNameArray.unshift(CELL_A1_PPI);
     }
 
     links.forEach((link) => {

--- a/server/controllers/network-sheet-parser.js
+++ b/server/controllers/network-sheet-parser.js
@@ -294,7 +294,7 @@ var parseNetworkSheet = function (sheet, network) {
 /*
  * This method detect the network type of the workbook file either grn or protein-protein-physical-interactions
  * If cellA1 = "cols regulators/ row targets" -> workbookType = grn
- * If cellA1 = "protein 1/protein 2" -> workbookType = "protein-protein-physical-interaction"
+ * If cellA1 = "cols protein1/ rows protein2" -> workbookType = "protein-protein-physical-interaction"
  * else undefined
 */
 
@@ -306,7 +306,7 @@ exports.workbookType = function (workbookFile) {
 
             if (cellA1 === "cols regulators/rows targets") {
                 workbookType = "grn";
-            } else if (cellA1 === "protein 1/protein 2") {
+            } else if (cellA1 === "cols protein1/ rows protein2") {
                 workbookType = "protein-protein-physical-interaction";
             } else {
                 workbookType = undefined;

--- a/server/controllers/network-sheet-parser.js
+++ b/server/controllers/network-sheet-parser.js
@@ -2,6 +2,7 @@
 // var path = require("path");
 // var demoWorkbooks = require(__dirname + "/demo-workbooks");
 
+const { CELL_A1_GRN, CELL_A1_PPI } = require("./constants");
 const { initWorkbook } = require("./helpers");
 
 var semanticChecker = require(__dirname + "/semantic-checker");
@@ -108,7 +109,7 @@ var parseNetworkSheet = function (sheet, network) {
 
     // Depending on the value of cellA1, we want to make a new property `networkType` which
     // will indicate the network type. THe web app then reads this to decide what to do next.
-    if (cellA1 !== "cols regulators/rows targets") {
+    if (cellA1 !== CELL_A1_GRN || cellA1 !== CELL_A1_PPI) {
         addWarning(
             network,
             constants.warnings.incorrectCellA1WorkbookWarning(sheet.name)
@@ -304,9 +305,9 @@ exports.workbookType = function (workbookFile) {
         if (sheet.name.toLowerCase() === "network") {
             const cellA1 = sheet.data[0][0];
 
-            if (cellA1 === "cols regulators/rows targets") {
+            if (cellA1 === CELL_A1_GRN) {
                 workbookType = "grn";
-            } else if (cellA1 === "cols protein1/ rows protein2") {
+            } else if (cellA1 === CELL_A1_PPI) {
                 workbookType = "protein-protein-physical-interaction";
             } else {
                 workbookType = undefined;

--- a/server/controllers/workbook-constants.js
+++ b/server/controllers/workbook-constants.js
@@ -102,7 +102,8 @@ module.exports = {
             return {
                 warningCode: "MISLABELED_NETWORK_CELL_A1",
                 errorDescription: `The top left cell of the ${sheetName} sheet is mislabeled.
-                Replace the incorrect label with \'cols regulators/rows targets\' exactly.`
+                Replace the incorrect label with \'cols regulators/ rows targets\' or \'cols 
+                protein1/ rows protein2'\ exactly.`
             };
         },
 

--- a/test/export-tests.js
+++ b/test/export-tests.js
@@ -896,7 +896,7 @@ describe("Export to spreadsheet", function () {
             {
                 name: "network",
                 data: [
-                    ["protein 1/protein 2", "Aim32p", "Ccr4p", "Erv1p"],
+                    ["cols protein1/ rows protein2", "Aim32p", "Ccr4p", "Erv1p"],
                     ["Aim32p", 0, 0, 0],
                     ["Ccr4p", 1, 1, 0],
                     ["Erv1p", 1, 0, 1]

--- a/test/export-tests.js
+++ b/test/export-tests.js
@@ -2,6 +2,7 @@ var expect = require("chai").expect;
 var extend = require("jquery-extend");
 var xlsx = require("node-xlsx");
 var test = require("./test");
+const { CELL_A1_PPI, CELL_A1_GRN } = require("../server/controllers/constants");
 
 var exportController = require(__dirname + "/../server/controllers/export-controller")();
 var constants = require(__dirname + "/../server/controllers/constants");
@@ -763,7 +764,7 @@ describe("Export to spreadsheet", function () {
             {
                 name: "network",
                 data: [
-                    ["cols regulators/rows targets", "ACE2", "AFT2", "CIN5"],
+                    [CELL_A1_GRN, "ACE2", "AFT2", "CIN5"],
                     ["ACE2", 1, 0, 0],
                     ["AFT2", 0, 1, 1],
                     ["CIN5", 0, 0, 1]
@@ -773,7 +774,7 @@ describe("Export to spreadsheet", function () {
             {
                 name: "network_weights",
                 data: [
-                    ["cols regulators/rows targets", "ACE2", "AFT2", "CIN5"],
+                    [CELL_A1_GRN, "ACE2", "AFT2", "CIN5"],
                     ["ACE2", 1, 0, 0],
                     ["AFT2", 0, 1, 1],
                     ["CIN5", 0, 0, 1]
@@ -896,7 +897,7 @@ describe("Export to spreadsheet", function () {
             {
                 name: "network",
                 data: [
-                    ["cols protein1/ rows protein2", "Aim32p", "Ccr4p", "Erv1p"],
+                    [CELL_A1_PPI, "Aim32p", "Ccr4p", "Erv1p"],
                     ["Aim32p", 0, 0, 0],
                     ["Ccr4p", 1, 1, 0],
                     ["Erv1p", 1, 0, 1]


### PR DESCRIPTION
Followed up with #1054, cell A1 named should be 'cols protein1/ rows protein2' instead of 'protein 1/protein 2'

Pull Request Checklist
- [x] Travis C.I. build passes
- [x] All five Demos look as expected when loaded
- [x] Reload works as expected
- [x] Loading file with Error brings up error modal, and it looks as expected
- [x] Loading file with Warning brings up warnings modal
- [x] Loading a network from the database looks as expected when loaded
- [x] Import works for both SIF and GraphML
- [x] Graph can be exported to SIF, GraphML and Excel
- [x] Graph can be exported to PNG, SVG and PDF
- [x] Expression data and Additional Sheets can be exported to Excel
- [x] Print works as expected
- [x] Restrict graph to viewport works as expected (check/uncheck)
- [x] Viewport Size Changing works as expected (small/medium/large/fit)
- [x] Toggle between Grid Layout and Force Graph Layout works as expected
- [x] Force Graph Parameter Sliders change the number above them and have an effect on the graph
- [x] Locking/Unlocking/Resetting/Undo Resetting the force graph parameters works as expected
- [x] Enabling and disabling node coloring works as expected
- [x] Node coloring options work as expected (selection top/bottom dataset, averaging values, changing max value)
- [x] Weighted graph loaded with the "Enable Edge Coloring" option checked appears as expected
- [x] Hide/Show Weights works as expected (always/never/upon mouseover)
- [x] Edge Weight Normalization Factor can be changed (set/reset)
- [x] Gray Edge Threshold can be changed, slider changes the number and has an effect on the graph
- [x] Checking Show Gray Edges as Dashed works as expected (check/uncheck)
- [x] D-pad left/right/top/bottom/center works as expected
- [x] Zoom slider changes number and has effect on graph (viewport and menu)
- [x] Right click on a node opens gene page, page is populated with correct data
