### PR TITLE
Fix issue #1099 to stop loading demo 1 when exporting sif, graphml

### DIFF
--- a/web-client/public/js/setup-load-and-import-handlers.js
+++ b/web-client/public/js/setup-load-and-import-handlers.js
@@ -183,10 +183,12 @@ export const setupLoadAndImportHandlers = (grnState) => {
     };
 
     const initializeDemoFile = (demoClass, demoPath, demoName) => {
-        // Deleted parameter `event`
-        $(demoClass).on("click", () => {
-            loadDemo(demoPath, demoClass, demoName);
-        });
+        $(".dropdown-menu li a").on("click", (event) => {
+            const selected = event.target.dataset.expression;
+            if (`.${selected}` === demoClass) {
+                loadDemo(demoPath, demoClass, demoName);
+            }
+        })
         $("#demoSourceDropdown").on("change", () => {
             const selected = `.${$("#demoSourceDropdown").val()}`;
             if (selected === demoClass) {

--- a/web-client/public/js/setup-load-and-import-handlers.js
+++ b/web-client/public/js/setup-load-and-import-handlers.js
@@ -188,7 +188,7 @@ export const setupLoadAndImportHandlers = (grnState) => {
             if (`.${selected}` === demoClass) {
                 loadDemo(demoPath, demoClass, demoName);
             }
-        })
+        });
         $("#demoSourceDropdown").on("change", () => {
             const selected = `.${$("#demoSourceDropdown").val()}`;
             if (selected === demoClass) {

--- a/web-client/views/components/demo.pug
+++ b/web-client/views/components/demo.pug
@@ -1,12 +1,12 @@
-ul(class='dropdown-menu' role='menu')
+ul(class='dropdown-menu' role='menu' id="demo-dropdown")
   li
-    a(href='#' class='unweighted') Demo #1: Unweighted GRN (15 genes, 28 edges, Dahlquist Lab unpublished data)
+    a(href='#' class='unweighted' data-expression="unweighted") Demo #1: Unweighted GRN (15 genes, 28 edges, Dahlquist Lab unpublished data)
   li
-    a(href='#' class='weighted') Demo #2: Weighted GRN (15 genes, 28 edges, Dahlquist Lab unpublished data)
+    a(href='#' class='weighted' data-expression="weighted") Demo #2: Weighted GRN (15 genes, 28 edges, Dahlquist Lab unpublished data)
   li
-    a(href='#' class='schadeInput') Demo #3: Unweighted GRN (21 genes, 31 edges)
+    a(href='#' class='schadeInput' data-expression="schadeInput") Demo #3: Unweighted GRN (21 genes, 31 edges)
   li
-    a(href='#' class='schadeOutput') Demo #4: Weighted GRN (21 genes, 31 edges, Schade et al. 2004 data)
+    a(href='#' class='schadeOutput' data-expression="schadeOutput") Demo #4: Weighted GRN (21 genes, 31 edges, Schade et al. 2004 data)
   li
-    a(href='#' class='ppi') Demo #5: PPI (18 proteins, 81 edges)
+    a(href='#' class='ppi' data-expression="ppi") Demo #5: PPI (18 proteins, 81 edges)
            


### PR DESCRIPTION
Pull Request Checklist
- [x] Travis C.I. build passes
- [x] All five Demos look as expected when loaded
- [x] Reload works as expected
- [x] Loading file with Error brings up error modal, and it looks as expected
- [x] Loading file with Warning brings up warnings modal
- [x] Loading a network from the database looks as expected when loaded
- [x] Import works for both SIF and GraphML
- [x] Graph can be exported to SIF, GraphML and Excel
- [x] Graph can be exported to PNG, SVG and PDF
- [x] Expression data and Additional Sheets can be exported to Excel
- [x] Print works as expected
- [x] Restrict graph to viewport works as expected (check/uncheck)
- [x] Viewport Size Changing works as expected (small/medium/large/fit)
- [x] Toggle between Grid Layout and Force Graph Layout works as expected
- [x] Force Graph Parameter Sliders change the number above them and have an effect on the graph
- [x] Locking/Unlocking/Resetting/Undo Resetting the force graph parameters works as expected
- [x] Enabling and disabling node coloring works as expected
- [x] Node coloring options work as expected (selection top/bottom dataset, averaging values, changing max value)
- [x] Weighted graph loaded with the "Enable Edge Coloring" option checked appears as expected
- [x] Hide/Show Weights works as expected (always/never/upon mouseover)
- [x] Edge Weight Normalization Factor can be changed (set/reset)
- [x] Gray Edge Threshold can be changed, slider changes the number and has an effect on the graph
- [x] Checking Show Gray Edges as Dashed works as expected (check/uncheck)
- [x] D-pad left/right/top/bottom/center works as expected
- [x] Zoom slider changes number and has effect on graph (viewport and menu)
- [x] Right click on a node opens gene page, page is populated with correct data
