### PR TITLE
Issue #1083 When check restrict graph to viewport the D-pad and zoom slider do not disappear and graph cannot exceed viewport

### DIFF
--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1502,16 +1502,27 @@ export var drawGraph = function (workbook) {
         // handle left x and top y boundaries to not exceed BOUNDARY_MARGIN
         minX = minX < BOUNDARY_MARGIN_X_L ? BOUNDARY_MARGIN_X_L : minX;
         minY = minY < BOUNDARY_MARGIN_Y_T ? BOUNDARY_MARGIN_Y_T : minY;
-        let width = maxX - minX;
+        
+        maxX =
+          maxX > -xTranslation / graphZoom + 5 / 2 + width / graphZoom - 5
+            ? -xTranslation / graphZoom + 5 / 2 + width / graphZoom - 5
+            : maxX;
+
+        maxY =
+          maxY > -yTranslation / graphZoom + 5 / 2 + height / graphZoom - 5
+            ? -yTranslation / graphZoom + 5 / 2 + height / graphZoom - 5
+            : maxY;
+
+        let flexiBoxWidth = maxX - minX;
         if (maxX < 0 && minX < 0) {
-            width = Math.abs(maxX) - Math.abs(minX);
+            flexiBoxWidth = Math.abs(maxX) - Math.abs(minX);
         } 
 
-        let height = maxY - minY;
+        let flexiBoxHeight = maxY - minY;
         if (maxY < 0 && minY < 0) {
-            height = Math.abs(maxY) - Math.abs(minY);
+            flexiBoxHeight = Math.abs(maxY) - Math.abs(minY);
         }
-        return {x: minX, y: minY, maxX: maxX, maxY: maxY, width: width, height: height};
+        return {x: minX, y: minY, maxX: maxX, maxY: maxY, width: flexiBoxWidth, height: flexiBoxHeight};
     }
 
     // this checks if zoomValue is in bounds when zoom in and out
@@ -1519,10 +1530,8 @@ export var drawGraph = function (workbook) {
         if (flexibleContainer) {
             updateZoomContainerInfo();
             if (flexibleContainer.width * zoomValue > width ) {
-                console.log("width out of bounds")
                 return false;
             } else if (flexibleContainer.height * zoomValue > height) {
-                console.log("height out of bounds")
                 return false;
             }
         }
@@ -1797,14 +1806,13 @@ export var drawGraph = function (workbook) {
     }
 
     function dragged (d) {
-        console.log(d, "d.fx", d3.event.x, "d.fy", d3.event.y)
         if (!adaptive) {
             if (d3.event.x + d.textWidth <= (-xTranslation / graphZoom + 5/2) + (width / graphZoom) - 5) {
                 d.fx = d3.event.x;
             } else {
                 d.fx = (-xTranslation / graphZoom + 5/2) + (width / graphZoom) - 5 - d.textWidth;
             }
-            if (d3.event.y + nodeHeight<= -yTranslation / graphZoom + 5 / 2 + height / graphZoom - 5) {
+            if (d3.event.y + nodeHeight <= -yTranslation / graphZoom + 5 / 2 + height / graphZoom - 5) {
                 d.fy = d3.event.y;
             } else {
                 d.fy = -yTranslation / graphZoom + 5 / 2 + height / graphZoom - 5 - nodeHeight;

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -35,8 +35,6 @@ import {
  * updateFunction being set when needed.
  */
 
-// Stack overflow link for trying to create a box containing the graph:
-// https://stackoverflow.com/questions/47544041/how-to-visualize-groups-of-nodes-in-a-d3-force-directed-graph-layout
 let mutationCallback = null;
 const resizeObserver = new MutationObserver((mutationsList, observer) => {
     if (typeof(mutationCallback) === "function") {
@@ -260,14 +258,14 @@ export var drawGraph = function (workbook) {
     function updateZoomContainerInfo () {
         // transform attribute of zoomContainer contains translation info about graph
         if (zoomContainer.attr("transform")) {
-            xTranslation = parseFloat(
+            xTranslation = Number(
               zoomContainer
                 .attr("transform")
                 .split("(")[1]
                 .split(",")[0]
             );
 
-            yTranslation = parseFloat(
+            yTranslation = Number(
               zoomContainer
                 .attr("transform")
                 .split("(")[1]

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -295,6 +295,7 @@ export var drawGraph = function (workbook) {
     let zoomScaleSliderLeft;
     let zoomScaleSliderRight;
     let prevGrnstateZoomVal;
+    let flexibleContainer = null;
 
     const updateAppBasedOnZoomValue = () => {
         let zoomDisplay;
@@ -436,8 +437,7 @@ export var drawGraph = function (workbook) {
             $("#restrict-graph-to-viewport span").removeClass("glyphicon-ok");
             $("input[name=viewport]").removeProp("checked");
             adaptive = true;
-            d3.select("rect").attr("stroke", "none");
-            d3.select("#flexibleContainerRect").attr("stroke", "none");
+            flexibleContainer = null;
             center();
         } else {
             $("#restrict-graph-to-viewport span").addClass("glyphicon-ok");
@@ -1386,7 +1386,6 @@ export var drawGraph = function (workbook) {
     };
 
     const BOUNDARY_MARGIN = 5;
-    let flexibleContainer = null;
 
     function viewportBoundsMoveDrag (graphZoom, dx, dy) {
         updateZoomContainerInfo();
@@ -1479,7 +1478,7 @@ export var drawGraph = function (workbook) {
         return {x: minX, y: minY, maxX: maxX, maxY: maxY, width: flexiBoxWidth, height: flexiBoxHeight};
     }
 
-    // this checks if zoomValue is in bounds when zoom in and out
+    // Checks if zoomValue is in bounds when zoom in and out
     function flexZoomInBounds (zoomValue) {
         if (flexibleContainer) {
             updateZoomContainerInfo();

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1577,11 +1577,9 @@ export var drawGraph = function (workbook) {
                 width ${Math.round(flexibleContainerRect.attr("width"))}
                 x ${Math.round(flexibleContainerRect.attr("x"))}
                 maxX ${Math.round(flexibleContainer.maxX)}
-                
                 height ${Math.round(flexibleContainerRect.attr("height"))}
                 y ${Math.round(flexibleContainerRect.attr("y"))}
                 maxY ${Math.round(flexibleContainer.maxY)}
-
                 `;
             $("#flexiBox-dimensions").text(flexDimensions);
 
@@ -1611,7 +1609,7 @@ export var drawGraph = function (workbook) {
                       selfReferringEdgeWidth;
                 }
                 // currentXPos bounds the graph when toggle to !adaptive and moves each of the nodes to be in bounds
-                var currentXPos = Math.max(BOUNDARY_MARGIN, Math.min(rightBoundary, d.x));
+                var currentXPos = Math.max(getBOUNDARY_MARGIN_X_L(), Math.min(rightBoundary, d.x));
                 if (
                   adaptive &&
                   width < MAX_WIDTH &&

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -310,6 +310,18 @@ export var drawGraph = function (workbook) {
                 return false;
             }
         } else {
+            // this is somewhat of a solution, still a white gap sometimes
+            if (
+              dx > 0 &&
+              (flexibleContainer.width +
+                flexibleContainer.x +
+                xTranslation +
+                dx * graphZoom) + flexibleContainer.x * graphZoom >=
+                width / graphZoom
+            ) {
+              console.log("4th x statement false");
+              return false;
+            }
 
         }
         

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1427,7 +1427,7 @@ export var drawGraph = function (workbook) {
     };
 
     // there is too much whitespace in flexiContainer
-    function calcFlexiBox () {
+    function calcFlexiBox (BOUNDARY_MARGIN_X_L) {
         const nodes = simulation.nodes()
         let nodeWidth = 0;
         if (nodes.length > 0) {
@@ -1470,12 +1470,15 @@ export var drawGraph = function (workbook) {
         // const xValues = xValuesPaths.concat(xValuesNodes);
         // const yValues = yValuesPaths.concat(yValuesNodes);
 
-        const minX = Math.min(...xValuesNodes);
+        let minX = Math.min(...xValuesNodes);
         const minY = Math.min(...yValuesNodes);
 
         const maxX = Math.max(...xValuesNodes) + nodeWidth;
         const maxY = Math.max(...yValuesNodes) + nodeHeight;
 
+        // handle left x boundary to not be less than 0 
+        console.log("left boundary", BOUNDARY_MARGIN_X_L)
+        minX = minX < BOUNDARY_MARGIN_X_L ? BOUNDARY_MARGIN_X_L : minX;
         return {x: minX, y: minY, width: maxX - minX, height: maxY - minY};
     }
 
@@ -1502,11 +1505,6 @@ export var drawGraph = function (workbook) {
       // limit flexContainer from exceeding bounding box
       // TODO: add 5 so flexibleContainerRect stays within BOUNDARY_MARGIN, remove hardcoded value later
       if (flexibleContainer) {
-        // x left bound
-        if (flexibleContainer.x < BOUNDARY_MARGIN_X_L) {
-        //   flexibleContainer.x = BOUNDARY_MARGIN_X_L;
-          console.log("left boundary exceeds", BOUNDARY_MARGIN_X_L);
-        }
         // x right bound
         if (
             (graphZoom * flexibleContainer.width +
@@ -1529,6 +1527,16 @@ export var drawGraph = function (workbook) {
         if (flexibleContainer.height > height - flexibleContainer.y) {
           flexibleContainer.height = height - flexibleContainer.y;
         }
+
+        const flexDimensions = `flex.x
+              ${flexibleContainer.x}
+              flex.width
+              ${flexibleContainer.width}
+              flex.y
+              ${flexibleContainer.y}
+              flex.height
+              ${flexibleContainer.height}`;
+        $("#flexiBox-dimensions").text(flexDimensions);
       }
     }
 
@@ -1551,44 +1559,44 @@ export var drawGraph = function (workbook) {
         let BOUNDARY_MARGIN_X_L = BOUNDARY_MARGIN;
         let BOUNDARY_MARGIN_X_R = BOUNDARY_MARGIN;
         let BOUNDARY_MARGIN_Y = BOUNDARY_MARGIN;
-        if (!adaptive && flexibleContainer && graphZoom >= 1) {
+        // if (!adaptive && flexibleContainer && graphZoom >= 1) {
+            // if (
+            //   Math.abs(xTranslation) >
+            //   Math.floor(flexibleContainer.x) * graphZoom
+            // ) {
+            // // bouncing behavior because for some reason 15 pixels too far to the right
+            //     BOUNDARY_MARGIN_X_L = Math.abs(xTranslation);
+            // }
+            // if (
+            //   xTranslation >
+            //   $container.width() -
+            //     (graphZoom * flexibleContainer.width +
+            //       graphZoom * flexibleContainer.x)
+            // ) {
+            //     BOUNDARY_MARGIN_X_R = Math.abs(xTranslation);
+            // }
+            // if (
+            //   Math.abs(yTranslation) >
+            //   Math.floor(flexibleContainer.y) * graphZoom
+            // ) {
+            //     BOUNDARY_MARGIN_Y = Math.abs(yTranslation);
+            // }
             
-            if (
-              Math.abs(xTranslation) >
-              Math.floor(flexibleContainer.x) * graphZoom
-            ) {
-            // bouncing behavior because for some reason 15 pixels too far to the right
-                BOUNDARY_MARGIN_X_L = Math.abs(xTranslation);
-            }
-            if (
-              xTranslation >
-              $container.width() -
-                (graphZoom * flexibleContainer.width +
-                  graphZoom * flexibleContainer.x)
-            ) {
-                BOUNDARY_MARGIN_X_R = Math.abs(xTranslation);
-            }
-            if (
-              Math.abs(yTranslation) >
-              Math.floor(flexibleContainer.y) * graphZoom
-            ) {
-                BOUNDARY_MARGIN_Y = Math.abs(yTranslation);
-            }
-        }
+        // }
         var SELF_REFERRING_Y_OFFSET = 6;
         var MAX_WIDTH = 5000;
         var MAX_HEIGHT = 5000;
         var OFFSET_VALUE = 5;
 
         if (!adaptive) {
-            flexibleContainer = calcFlexiBox();
+            flexibleContainer = calcFlexiBox(BOUNDARY_MARGIN_X_L);
             flexRectLimitBounds(BOUNDARY_MARGIN_X_R, BOUNDARY_MARGIN_X_L, BOUNDARY_MARGIN_Y);
 
             flexibleContainerRect
-                .attr("x", flexibleContainer.x)
-                .attr("y", flexibleContainer.y)
-                .attr("width", flexibleContainer.width)
-                .attr("height", flexibleContainer.height);
+              .attr("x", flexibleContainer.x)
+              .attr("y", flexibleContainer.y)
+              .attr("width", flexibleContainer.width)
+              .attr("height", flexibleContainer.height);
             // console.log(flexibleContainer.x, flexibleContainer.width)
         }
         

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -369,10 +369,11 @@ export var drawGraph = function (workbook) {
 
         // This controls actual movement of slider
         if (adaptive || (!adaptive && flexRectInBounds(calcGraphZoom))) {
-        // don't really want to center anymore for zooming since don't care if see bounding box anymore
+        // TODO: don't really want to center anymore for zooming since don't care if see bounding box anymore
         // if don't center, then get issue of zooming into the box since not inside the width of the viewport
             if (!adaptive) {
                 center();
+                updateZoomContainerInfo();
                 centerXCoord = xTranslation
             }
 
@@ -1495,25 +1496,21 @@ export var drawGraph = function (workbook) {
             // x left bound
             if (flexibleContainer.x < 0) {
                 flexibleContainer.x = 0;
-                return false
             }
 
             // x right bound
-            if (!(flexibleContainer.width - flexibleContainer.x  <= width * graphZoom)) {
-                flexibleContainer.width = (width - flexibleContainer.x) * graphZoom;
-                return false
+            if (flexibleContainer.width > width - flexibleContainer.x) {
+                flexibleContainer.width = width - flexibleContainer.x;
             }
 
             // y top bound
             if (flexibleContainer.y < 0) {
                 flexibleContainer.y = 0;
-                return false
             }
             
             // y bottom bound
-            if (!(flexibleContainer.height - flexibleContainer.y <= height * graphZoom)) {
-                flexibleContainer.height = (height - flexibleContainer.y) * graphZoom;
-                return false
+            if (flexibleContainer.height > height - flexibleContainer.y) {
+                flexibleContainer.height = height - flexibleContainer.y;
             }
         }
     }
@@ -1532,15 +1529,14 @@ export var drawGraph = function (workbook) {
             return edge ? 17 + (getEdgeThickness(edge) / 2) : 0;
         };
 
-        
-        
         let BOUNDARY_MARGIN = 5;
         // xTranslation > 0 -> moved to the left? wo right boundary hidden, left is too short
-        let BOUNDARY_MARGIN_X_LEFT = adaptive ? BOUNDARY_MARGIN : graphZoom >= 1 && xTranslation <= centerXCoord ? Math.abs(xTranslation) * graphZoom: BOUNDARY_MARGIN;
-        let BOUNDARY_MARGIN_X_RIGHT = adaptive ? BOUNDARY_MARGIN : graphZoom >= 1 && xTranslation >= centerXCoord ?  Math.abs(xTranslation) * graphZoom: BOUNDARY_MARGIN;
-        let BOUNDARY_MARGIN_Y = adaptive? BOUNDARY_MARGIN: graphZoom >= 1 ? Math.abs(yTranslation) * graphZoom: BOUNDARY_MARGIN;
-        // let BOUNDARY_MARGIN_X = BOUNDARY_MARGIN
-        // let BOUNDARY_MARGIN_Y = BOUNDARY_MARGIN
+        // let BOUNDARY_MARGIN_X_LEFT = adaptive ? BOUNDARY_MARGIN : graphZoom >= 1 && xTranslation <= centerXCoord ? Math.abs(xTranslation) * graphZoom: BOUNDARY_MARGIN;
+        // let BOUNDARY_MARGIN_X_RIGHT = adaptive ? BOUNDARY_MARGIN : graphZoom >= 1 && xTranslation >= centerXCoord ?  Math.abs(xTranslation) * graphZoom: BOUNDARY_MARGIN;
+        // let BOUNDARY_MARGIN_Y = adaptive? BOUNDARY_MARGIN: graphZoom >= 1 ? Math.abs(yTranslation) * graphZoom: BOUNDARY_MARGIN;
+        let BOUNDARY_MARGIN_X_LEFT = BOUNDARY_MARGIN
+        let BOUNDARY_MARGIN_X_RIGHT = BOUNDARY_MARGIN
+        let BOUNDARY_MARGIN_Y = BOUNDARY_MARGIN
         var SELF_REFERRING_Y_OFFSET = 6;
         var MAX_WIDTH = 5000;
         var MAX_HEIGHT = 5000;
@@ -1568,7 +1564,9 @@ export var drawGraph = function (workbook) {
                 var selfReferringEdgeWidth = (selfReferringEdge ? getSelfReferringRadius(selfReferringEdge) +
                     selfReferringEdge.strokeWidth + 2 : 0);
                 // this creates too much whitespace, want it to be the BOUNDARY_MARGIN_X when can see right side of borerbox
-
+                // a stack overflow link to look at: https://stackoverflow.com/questions/26781129/d3-v2-prevent-zooming-and-panning-chart-outside-viewport
+                // could also look at this: https://observablehq.com/@john-guerra/force-directed-adjusted
+                // and look at this too: https://www.w3.org/TR/SVG/coords.html
                 var rightBoundary = width -(d.textWidth + OFFSET_VALUE) - BOUNDARY_MARGIN_X_RIGHT - selfReferringEdgeWidth;
                 // currentXPos bounds the graph when toggle to !adaptive and moves each of the nodes to be in bounds
                 var currentXPos = Math.max(BOUNDARY_MARGIN_X_LEFT, Math.min(rightBoundary, d.x));

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -214,12 +214,12 @@ export var drawGraph = function (workbook) {
 
     var boundingBoxContainer = zoomContainer.append("g"); // appended another g here...
 
-    var flexibleContainerRect = svg
-        .append("rect")
+    var flexibleContainerRect = boundingBoxContainer.append("rect")
         .attr("class", "boundingBox")
         .attr("stroke", "black")
         .attr("stroke-width", 1)
         .attr("fill", "none")
+        // .append("g")
 
     var zoom = d3.zoom()
         .scaleExtent([MIN_SCALE, ZOOM_ADAPTIVE_MAX_SCALE])
@@ -228,6 +228,7 @@ export var drawGraph = function (workbook) {
     svg.style("pointer-events", "all").call(zoomDrag)
         .style("font-family", "sans-serif");
 
+    // this is why drag happens inside the flexibleContainerRect
     function zoomed () {
         zoomContainer.attr("transform", d3.event.transform);
     }
@@ -1404,13 +1405,10 @@ export var drawGraph = function (workbook) {
         }
     };
 
-
-    //need to manipulate tick so that box changes whenever the nodes move
-
     //node has all the nodes
     var nodes = simulation.nodes()
 
-    const calculateFlexibleBox = (nodes) => {
+    function calcFlexiBox (nodes) {
         const xValues = nodes.map(node => node.x)
         const yValues = nodes.map(node => node.y)
         const minX = Math.min(...xValues)
@@ -1421,7 +1419,7 @@ export var drawGraph = function (workbook) {
         return {x: minX, y: minY, width: maxX - minX, height: maxY - minY}
     }
 
-    let flexibleContainer = calculateFlexibleBox(nodes)
+    let flexibleContainer = calcFlexiBox(nodes)
     
     // Tick only runs while the graph physics are still running.
     // (I.e. when the graph is completely relaxed, tick stops running.)
@@ -1442,7 +1440,7 @@ export var drawGraph = function (workbook) {
         var MAX_HEIGHT = 5000;
         var OFFSET_VALUE = 5;
 
-        flexibleContainer = calculateFlexibleBox(nodes)
+        flexibleContainer = calcFlexiBox(nodes);
 
         flexibleContainerRect
             .attr("x", flexibleContainer.x)

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1540,22 +1540,17 @@ export var drawGraph = function (workbook) {
         };
 
         let BOUNDARY_MARGIN = 5;
-        // xTranslation > 0 -> moved to the left? wo right boundary hidden, left is too short
-        // let BOUNDARY_MARGIN_X_LEFT = adaptive ? BOUNDARY_MARGIN : graphZoom >= 1 && xTranslation <= centerXCoord ? Math.abs(xTranslation) * graphZoom: BOUNDARY_MARGIN;
-        // let BOUNDARY_MARGIN_X_LEFT = adaptive ? BOUNDARY_MARGIN : graphZoom >= 1 && xTranslation <= centerXCoord ? Math.abs(xTranslation) * graphZoom: BOUNDARY_MARGIN;
-
-        // let BOUNDARY_MARGIN_X_RIGHT = adaptive ? BOUNDARY_MARGIN : graphZoom >= 1 && xTranslation >= centerXCoord ? Math.abs(xTranslation) * graphZoom: BOUNDARY_MARGIN;
-
-        // let BOUNDARY_MARGIN_Y = adaptive? BOUNDARY_MARGIN: graphZoom >= 1 ? Math.abs(yTranslation) * graphZoom: BOUNDARY_MARGIN;
         // Left and right boundary margins:
         let BOUNDARY_MARGIN_X_L = BOUNDARY_MARGIN;
         let BOUNDARY_MARGIN_X_R = BOUNDARY_MARGIN;
+        let BOUNDARY_MARGIN_Y = BOUNDARY_MARGIN;
         if (!adaptive && flexibleContainer && graphZoom >= 1) {
             
             if (
               Math.abs(xTranslation) >
               Math.floor(flexibleContainer.x) * graphZoom
             ) {
+            // bouncing behavior because for some reason 15 pixels too far to the right
                 BOUNDARY_MARGIN_X_L = Math.abs(xTranslation);
             }
             if (
@@ -1564,13 +1559,16 @@ export var drawGraph = function (workbook) {
                 (graphZoom * flexibleContainer.width +
                   graphZoom * flexibleContainer.x)
             ) {
-                console.log(flexibleContainer.x + flexibleContainer.width, xTranslation)
                 BOUNDARY_MARGIN_X_R = Math.abs(xTranslation);
+                console.log("BOUNDARY_MARGIN_X_R", BOUNDARY_MARGIN_X_R, flexibleContainer.x + flexibleContainer.width)
+            }
+            if (
+              Math.abs(yTranslation) >
+              Math.floor(flexibleContainer.y) * graphZoom
+            ) {
+                BOUNDARY_MARGIN_Y = Math.abs(yTranslation);
             }
         }
-        // must be equal to the left border of exportContainer * graphZoom, right?
-        // export container - exportContainer * graphZoom and then take into account xTranslation for margin
-        let BOUNDARY_MARGIN_Y = BOUNDARY_MARGIN
         var SELF_REFERRING_Y_OFFSET = 6;
         var MAX_WIDTH = 5000;
         var MAX_HEIGHT = 5000;
@@ -1600,11 +1598,12 @@ export var drawGraph = function (workbook) {
                 // could also look at this: https://observablehq.com/@john-guerra/force-directed-adjusted
                 // and look at this too: https://www.w3.org/TR/SVG/coords.html
                 var rightBoundary = width -(d.textWidth + OFFSET_VALUE) - BOUNDARY_MARGIN_X_R - selfReferringEdgeWidth;
+                console.log("rightBoundary", rightBoundary, width, d.textWidth, BOUNDARY_MARGIN_X_R, selfReferringEdgeWidth)
                 // currentXPos bounds the graph when toggle to !adaptive and moves each of the nodes to be in bounds
                 var currentXPos = Math.max(BOUNDARY_MARGIN_X_L, Math.min(rightBoundary, d.x));
                 if (width < MAX_WIDTH &&
                     (currentXPos === BOUNDARY_MARGIN_X_L || currentXPos === rightBoundary)) {
-                    if (!d3.select(this).classed("fixed")) {
+                    // if (!d3.select(this).classed("fixed")) {
                         width += OFFSET_VALUE;
                         boundingBoxContainer.attr("width", width);
 
@@ -1620,7 +1619,7 @@ export var drawGraph = function (workbook) {
                             .attr("x", function (d) {
                                 return d.x;
                             });
-                    }
+                    // }
                 }
                 return d.x = currentXPos;
             }).attr("y", function (d) {
@@ -1630,9 +1629,9 @@ export var drawGraph = function (workbook) {
                 var bottomBoundary = height - nodeHeight - BOUNDARY_MARGIN_Y - selfReferringEdgeHeight;
                 // currentYPos bounds the graph when toggle to !adaptive and moves each of the nodes to be in bounds
                 var currentYPos = Math.max(BOUNDARY_MARGIN_Y, Math.min(bottomBoundary, d.y));
-                if (adaptive && height < MAX_HEIGHT &&
+                if (height < MAX_HEIGHT &&
                   (currentYPos === BOUNDARY_MARGIN_Y || currentYPos === bottomBoundary)) {
-                    if (!d3.select(this).classed("fixed")) {
+                    // if (!d3.select(this).classed("fixed")) {
                         height += OFFSET_VALUE;
                         boundingBoxContainer.attr("height", height);
                         link
@@ -1646,7 +1645,7 @@ export var drawGraph = function (workbook) {
                         node.attr("y", function (d) {
                             return d.y;
                         });
-                    }
+                    // }
                 }
                 return d.y = currentYPos;
             }).attr("transform", function (d) {

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1414,57 +1414,56 @@ export var drawGraph = function (workbook) {
     // let paths = link.selectAll("path").data()
 
     function calcFlexiBox (nodes) {
-        if (nodes) {
-            let nodeWidth = 0;
-            if (nodes.length > 0) {
-                nodeWidth = nodes[0].textWidth + 8;
-            }
+        let nodeWidth = 0;
+        if (nodes.length > 0) {
+            nodeWidth = nodes[0].textWidth + 8;
+        }
 
-            let xValuesPaths = []
-            let yValuesPaths = []
+        let xValuesPaths = []
+        let yValuesPaths = []
 
-            // this would reassign the values of pathData, since no value being assigned, then the value would be null
-            link.selectAll("path").each( function(pathData) {
-                if (pathData.source) {
-                    // Log the "d" attribute for each path
-                    const controlPoints = d3.select(this).attr("d");
+        // this would reassign the values of pathData, since no value being assigned, then the value would be null
+        link.selectAll("path").each( function(pathData) {
+            if (pathData.source) {
+                // Log the "d" attribute for each path
+                const controlPoints = d3.select(this).attr("d");
+                if (controlPoints) {
                     if (controlPoints.includes("A")) {
                         const splitSpaces = controlPoints.split(" ");
-                        const controlPoint1 = splitSpaces[0].split("M")[1].split(",");
-                        const controlPoint1X = controlPoint1[0];
-                        const controlPoint1Y = controlPoint1[1];
-                        console.log("A contains", controlPoint1X, controlPoint1Y);
+                        const controlPoint = splitSpaces[0].split("M")[1].split(",");
+                        const controlPointX = controlPoint[0];
+                        const controlPointY = controlPoint[1];
+                        // console.log(typeof(controlPointX), typeof(controlPointY))
+                        xValuesPaths.push(parseFloat(controlPointX))
+                        yValuesPaths.push(parseFloat(controlPointY))
                     }
-                    else {
+                    else if (controlPoints.includes("C")) {
                         const splitC = controlPoints.split("C");
-                        const splitM = splitC[0].split("M")[1].split(",");
-                        xValuesPaths.push(splitM[0]);
-                        yValuesPaths.push(splitM[1]);
 
                         splitC[1].split(",").forEach((coordinates) => {
                             const splitSpaces = coordinates.split(" ");
-                            const xValue = splitSpaces[splitSpaces.length - 2]
+                            const xValue = splitSpaces[splitSpaces.length - 2];
                             const yValue = splitSpaces[splitSpaces.length - 1];
-                            xValuesPaths.push(xValue)
-                            yValuesPaths.push(yValue)
-                        })
+                            xValuesPaths.push(parseFloat(xValue));
+                            yValuesPaths.push(parseFloat(yValue));
+                        });
                     }
                 }
-            });
+            }
+        });
 
-            const xValuesNodes = nodes.map((node) => node.x);
-            const yValuesNodes = nodes.map((node) => node.y);
+        const xValuesNodes = nodes.map((node) => node.x);
+        const yValuesNodes = nodes.map((node) => node.y);
 
-            const xValues = xValuesPaths.concat(xValuesNodes);
-            const yValues = yValuesPaths.concat(yValuesNodes);
+        const xValues = xValuesPaths.concat(xValuesNodes);
+        const yValues = yValuesPaths.concat(yValuesNodes);
 
-            const minX = Math.min(...xValues);
-            const minY = Math.min(...yValues);
+        const minX = Math.min(...xValues);
+        const minY = Math.min(...yValues);
 
-            const maxX = Math.max(...xValues) + nodeWidth;
-            const maxY = Math.max(...yValues) + nodeHeight;
-            return {x: minX, y: minY, width: maxX - minX, height: maxY - minY};
-        }
+        const maxX = Math.max(...xValues) + nodeWidth;
+        const maxY = Math.max(...yValues) + nodeHeight;
+        return {x: minX, y: minY, width: maxX - minX, height: maxY - minY};
     }
 
     // don't set flexibleContainer = calcFlexiBox or else the function does not stop running, only want to run on tick

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -281,56 +281,6 @@ export var drawGraph = function (workbook) {
         }
     };
 
-    function viewportBoundsMoveDrag(graphZoom, dx, dy, dPadMove) {
-        updateZoomContainerInfo();
-        flexibleContainer = calcFlexiBox()
-        // left border
-        if (xTranslation < 0 &&
-              Math.abs(xTranslation) >=
-                Math.floor(flexibleContainer.x) * graphZoom + dx * graphZoom)
-        {
-            return false;
-        }
-
-        //dPad movement when moving left
-        if (
-          dPadMove &&
-          xTranslation < 0 &&
-          dx < 0 &&
-          Math.abs(xTranslation + dx) > flexibleContainer.x * graphZoom
-        ) {
-            return false;
-        }
-
-        // right border
-        if (xTranslation + dx > width - (graphZoom * flexibleContainer.width + graphZoom * flexibleContainer.x)) {
-            return false
-        }
-
-        // Y-axis boundaries
-        // prevents graph from going through top border
-        if (yTranslation < 0 &&
-          Math.abs(yTranslation) >= Math.floor(flexibleContainer.y) * graphZoom &&
-          (dy < 0 ||
-            (dy > 0 &&
-              Math.abs(yTranslation) >= Math.floor(flexibleContainer.y) + dy * graphZoom))
-        ) {
-            return false;
-        }
-
-        // moving up with dPad
-        if (dPadMove && yTranslation < 0 && dy < 0 && Math.abs(yTranslation + dy) > flexibleContainer.y) {
-            return false
-        }
-        
-        // bottom border
-        if (yTranslation + dy > height - (graphZoom * flexibleContainer.height + graphZoom * flexibleContainer.y)) {
-            return false
-        }
-
-        return true
-    };
-
     // controls reading movement of zoomSlider and scaling graph to that zoomScale
     const setGraphZoom = zoomScale => {
         if (zoomScale < MIDDLE_SCALE) {
@@ -1433,6 +1383,56 @@ export var drawGraph = function (workbook) {
     };
 
     const BOUNDARY_MARGIN = 5;
+    function viewportBoundsMoveDrag(graphZoom, dx, dy, dPadMove) {
+        updateZoomContainerInfo();
+        flexibleContainer = calcFlexiBox()
+        // left border
+        if (xTranslation < 0 &&
+              Math.abs(xTranslation) >=
+                Math.floor(flexibleContainer.x) * graphZoom + dx * graphZoom)
+        {
+            return false;
+        }
+
+        //dPad movement when moving left
+        if (
+          dPadMove &&
+          xTranslation < 0 &&
+          dx < 0 &&
+          Math.abs(xTranslation + dx) > flexibleContainer.x * graphZoom
+        ) {
+            return false;
+        }
+
+        // right border
+        if (xTranslation + dx > width - (graphZoom * flexibleContainer.width + graphZoom * flexibleContainer.x)) {
+            return false
+        }
+
+        // Y-axis boundaries
+        // prevents graph from going through top border
+        if (yTranslation < 0 &&
+          Math.abs(yTranslation) >= Math.floor(flexibleContainer.y) * graphZoom &&
+          (dy < 0 ||
+            (dy > 0 &&
+              Math.abs(yTranslation) >= Math.floor(flexibleContainer.y) + dy * graphZoom))
+        ) {
+            return false;
+        }
+
+        // moving up with dPad
+        if (dPadMove && yTranslation < 0 && dy < 0 && Math.abs(yTranslation + dy) > flexibleContainer.y) {
+            return false
+        }
+
+        // bottom border
+        if (yTranslation + dy > height - (graphZoom * flexibleContainer.height + graphZoom * flexibleContainer.y)) {
+            return false
+        }
+
+        return true
+    };
+    
     function calcFlexiBox () {
         const nodes = simulation.nodes()
         let nodeWidth = 0;

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1527,17 +1527,28 @@ export var drawGraph = function (workbook) {
             if (Math.abs(xTranslation) >=
               Math.floor(flexibleContainer.x) * graphZoom
             ) {
+                console.log("left bound violated")
                 BOUNDARY_MARGIN_X_L = Math.abs(xTranslation) / graphZoom;
             }
+            console.log($container.width() -
+                  (graphZoom * flexibleContainer.width +
+                    graphZoom * flexibleContainer.x))
             if (
-              xTranslation >
+              xTranslation >=
               $container.width() -
                 (graphZoom * flexibleContainer.width +
                   graphZoom * flexibleContainer.x)
             ) {
-              console.log("right bound violated");
-              BOUNDARY_MARGIN_X_R = Math.abs(xTranslation) / graphZoom;
-            }
+                console.log("right bound violated");
+                if (flexibleContainer.x * graphZoom < $container.width() / graphZoom / 2){
+                    BOUNDARY_MARGIN_X_R =
+                      $container.width() -
+                      (graphZoom * flexibleContainer.width +
+                        graphZoom * flexibleContainer.x);
+                } else {
+                    BOUNDARY_MARGIN_X_R = Math.abs(xTranslation) / graphZoom;
+                }
+              }
             if (
               Math.abs(yTranslation) >=
               Math.floor(flexibleContainer.y) * graphZoom
@@ -1559,25 +1570,29 @@ export var drawGraph = function (workbook) {
 
         if (!adaptive) {
             flexibleContainer = calcFlexiBox(BOUNDARY_MARGIN_X_L, BOUNDARY_MARGIN_X_R, BOUNDARY_MARGIN_Y_T, BOUNDARY_MARGIN_Y_B);
+            /*
+             yTrnslt
+                ${Math.round(yTranslation)}
+            flx.y
+                ${Math.round(flexibleContainer.y)}
+                flx.h
+                ${Math.round(flexibleContainer.height)} 
+            boundY
+                ${Math.round(BOUNDARY_MARGIN_Y_T)}
+                ${Math.round(BOUNDARY_MARGIN_Y_B)}*/
             const flexDimensions = `xTrnslt
                 ${Math.round(xTranslation)}
-                yTrnslt
-                ${Math.round(yTranslation)}
                 flx.x
                 ${Math.round(flexibleContainer.x)}
                 flx.w
                 ${Math.round(flexibleContainer.width)}
-                flx.y
-                ${Math.round(flexibleContainer.y)}
-                flx.h
-                ${Math.round(flexibleContainer.height)}
-                
+                flx.x+flx.w
+                ${Math.round(flexibleContainer.x + flexibleContainer.width)}
+                flxx+w scaled
+                ${Math.round((flexibleContainer.x + flexibleContainer.width) * graphZoom) }
                 boundX
                 ${Math.round(BOUNDARY_MARGIN_X_L)}
-                ${Math.round(BOUNDARY_MARGIN_X_R)}
-                boundY
-                ${Math.round(BOUNDARY_MARGIN_Y_T)}
-                ${Math.round(BOUNDARY_MARGIN_Y_B)}`;
+                ${Math.round(BOUNDARY_MARGIN_X_R)}`;
             $("#flexiBox-dimensions").text(flexDimensions);
 
             flexibleContainerRect
@@ -1600,7 +1615,7 @@ export var drawGraph = function (workbook) {
                 // could also look at this: https://observablehq.com/@john-guerra/force-directed-adjusted
                 // and look at this too: https://www.w3.org/TR/SVG/coords.html
                 var rightBoundary = width -(d.textWidth + OFFSET_VALUE) - BOUNDARY_MARGIN_X_R - selfReferringEdgeWidth;
-                // console.log("rightBoundary", rightBoundary, width, d.textWidth, BOUNDARY_MARGIN_X_R, selfReferringEdgeWidth)
+                // console.log("rightBoundary", rightBoundary)
                 // currentXPos bounds the graph when toggle to !adaptive and moves each of the nodes to be in bounds
                 var currentXPos = Math.max(BOUNDARY_MARGIN_X_L, Math.min(rightBoundary, d.x));
                 if (adaptive && width < MAX_WIDTH &&

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1427,7 +1427,7 @@ export var drawGraph = function (workbook) {
     };
 
     // there is too much whitespace in flexiContainer
-    function calcFlexiBox (BOUNDARY_MARGIN_X_L) {
+    function calcFlexiBox (BOUNDARY_MARGIN_X_L, BOUNDARY_MARGIN_X_R) {
         const nodes = simulation.nodes()
         let nodeWidth = 0;
         if (nodes.length > 0) {
@@ -1471,14 +1471,15 @@ export var drawGraph = function (workbook) {
         // const yValues = yValuesPaths.concat(yValuesNodes);
 
         let minX = Math.min(...xValuesNodes);
-        const minY = Math.min(...yValuesNodes);
+        let minY = Math.min(...yValuesNodes);
 
-        const maxX = Math.max(...xValuesNodes) + nodeWidth;
-        const maxY = Math.max(...yValuesNodes) + nodeHeight;
+        let maxX = Math.max(...xValuesNodes) + nodeWidth;
+        let maxY = Math.max(...yValuesNodes) + nodeHeight;
 
-        // handle left x boundary to not be less than 0 
-        console.log("left boundary", BOUNDARY_MARGIN_X_L)
+        // handle left x and y boundaries to not exceed BOUNDARY_MARGIN
         minX = minX < BOUNDARY_MARGIN_X_L ? BOUNDARY_MARGIN_X_L : minX;
+        // TODO: probably need to factor in graphZoom
+        maxX = maxX > $container.width() ? $container.width() - BOUNDARY_MARGIN_X_R : maxX;
         return {x: minX, y: minY, width: maxX - minX, height: maxY - minY};
     }
 
@@ -1527,16 +1528,6 @@ export var drawGraph = function (workbook) {
         if (flexibleContainer.height > height - flexibleContainer.y) {
           flexibleContainer.height = height - flexibleContainer.y;
         }
-
-        const flexDimensions = `flex.x
-              ${flexibleContainer.x}
-              flex.width
-              ${flexibleContainer.width}
-              flex.y
-              ${flexibleContainer.y}
-              flex.height
-              ${flexibleContainer.height}`;
-        $("#flexiBox-dimensions").text(flexDimensions);
       }
     }
 
@@ -1589,8 +1580,17 @@ export var drawGraph = function (workbook) {
         var OFFSET_VALUE = 5;
 
         if (!adaptive) {
-            flexibleContainer = calcFlexiBox(BOUNDARY_MARGIN_X_L);
-            flexRectLimitBounds(BOUNDARY_MARGIN_X_R, BOUNDARY_MARGIN_X_L, BOUNDARY_MARGIN_Y);
+            flexibleContainer = calcFlexiBox(BOUNDARY_MARGIN_X_L, BOUNDARY_MARGIN_X_R);
+
+            const flexDimensions = `flex.x
+              ${flexibleContainer.x}
+              flex.width
+              ${flexibleContainer.width}
+              flex.y
+              ${flexibleContainer.y}
+              flex.height
+              ${flexibleContainer.height}`;
+            $("#flexiBox-dimensions").text(flexDimensions);
 
             flexibleContainerRect
               .attr("x", flexibleContainer.x)

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1427,7 +1427,7 @@ export var drawGraph = function (workbook) {
     };
 
     // there is too much whitespace in flexiContainer
-    function calcFlexiBox (BOUNDARY_MARGIN_X_L, BOUNDARY_MARGIN_X_R) {
+    function calcFlexiBox (BOUNDARY_MARGIN_X_L, BOUNDARY_MARGIN_X_R, BOUNDARY_MARGIN_Y) {
         const nodes = simulation.nodes()
         let nodeWidth = 0;
         if (nodes.length > 0) {
@@ -1471,15 +1471,17 @@ export var drawGraph = function (workbook) {
         // const yValues = yValuesPaths.concat(yValuesNodes);
 
         let minX = Math.min(...xValuesNodes);
-        let minY = Math.min(...yValuesNodes);
-
         let maxX = Math.max(...xValuesNodes) + nodeWidth;
+
+        let minY = Math.min(...yValuesNodes);
         let maxY = Math.max(...yValuesNodes) + nodeHeight;
 
         // handle left x and y boundaries to not exceed BOUNDARY_MARGIN
         minX = minX < BOUNDARY_MARGIN_X_L ? BOUNDARY_MARGIN_X_L : minX;
         // TODO: probably need to factor in graphZoom
         maxX = maxX > $container.width() ? $container.width() - BOUNDARY_MARGIN_X_R : maxX;
+        minY = minY < BOUNDARY_MARGIN_Y ? BOUNDARY_MARGIN_Y : minY;
+        maxY = maxY > $container.height() ? $container.height() - BOUNDARY_MARGIN_Y : maxY;
         return {x: minX, y: minY, width: maxX - minX, height: maxY - minY};
     }
 
@@ -1506,20 +1508,6 @@ export var drawGraph = function (workbook) {
       // limit flexContainer from exceeding bounding box
       // TODO: add 5 so flexibleContainerRect stays within BOUNDARY_MARGIN, remove hardcoded value later
       if (flexibleContainer) {
-        // x right bound
-        if (
-            (graphZoom * flexibleContainer.width +
-              graphZoom * flexibleContainer.x) > $container.width() * graphZoom - BOUNDARY_MARGIN_X_R
-        ) {
-            // flexibleContainer.width = $container.width() - flexibleContainer.width - BOUNDARY_MARGIN_X_R;
-          console.log(
-            "right boundary exceeds",
-            BOUNDARY_MARGIN_X_R,
-            $container.width() -
-              (graphZoom * flexibleContainer.width +
-                graphZoom * flexibleContainer.x)
-          );
-        }
         // y top bound
         if (flexibleContainer.y < BOUNDARY_MARGIN_Y) {
           flexibleContainer.y = BOUNDARY_MARGIN_Y;
@@ -1580,8 +1568,7 @@ export var drawGraph = function (workbook) {
         var OFFSET_VALUE = 5;
 
         if (!adaptive) {
-            flexibleContainer = calcFlexiBox(BOUNDARY_MARGIN_X_L, BOUNDARY_MARGIN_X_R);
-
+            flexibleContainer = calcFlexiBox(BOUNDARY_MARGIN_X_L, BOUNDARY_MARGIN_X_R, BOUNDARY_MARGIN_Y);
             const flexDimensions = `flex.x
               ${flexibleContainer.x}
               flex.width

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1486,7 +1486,7 @@ export var drawGraph = function (workbook) {
         if (flexibleContainer) {
             updateZoomContainerInfo();
             if (flexibleContainer.width * zoomValue > width ) {
-                console.log("width out of bounds", flexibleContainer.x, flexibleContainer.y)
+                console.log("width out of bounds")
                 return false;
             } else if (flexibleContainer.height * zoomValue > height) {
                 console.log("height out of bounds")
@@ -1599,12 +1599,12 @@ export var drawGraph = function (workbook) {
                 // could also look at this: https://observablehq.com/@john-guerra/force-directed-adjusted
                 // and look at this too: https://www.w3.org/TR/SVG/coords.html
                 var rightBoundary = width -(d.textWidth + OFFSET_VALUE) - BOUNDARY_MARGIN_X_R - selfReferringEdgeWidth;
-                console.log("rightBoundary", rightBoundary, width, d.textWidth, BOUNDARY_MARGIN_X_R, selfReferringEdgeWidth)
+                // console.log("rightBoundary", rightBoundary, width, d.textWidth, BOUNDARY_MARGIN_X_R, selfReferringEdgeWidth)
                 // currentXPos bounds the graph when toggle to !adaptive and moves each of the nodes to be in bounds
                 var currentXPos = Math.max(BOUNDARY_MARGIN_X_L, Math.min(rightBoundary, d.x));
-                if (width < MAX_WIDTH &&
+                if (adaptive && width < MAX_WIDTH &&
                     (currentXPos === BOUNDARY_MARGIN_X_L || currentXPos === rightBoundary)) {
-                    // if (!d3.select(this).classed("fixed")) {
+                    if (!d3.select(this).classed("fixed")) {
                         width += OFFSET_VALUE;
                         boundingBoxContainer.attr("width", width);
 
@@ -1620,7 +1620,7 @@ export var drawGraph = function (workbook) {
                             .attr("x", function (d) {
                                 return d.x;
                             });
-                    // }
+                    }
                 }
                 return d.x = currentXPos;
             }).attr("y", function (d) {
@@ -1630,9 +1630,9 @@ export var drawGraph = function (workbook) {
                 var bottomBoundary = height - nodeHeight - BOUNDARY_MARGIN_Y - selfReferringEdgeHeight;
                 // currentYPos bounds the graph when toggle to !adaptive and moves each of the nodes to be in bounds
                 var currentYPos = Math.max(BOUNDARY_MARGIN_Y, Math.min(bottomBoundary, d.y));
-                if (height < MAX_HEIGHT &&
+                if (adaptive && height < MAX_HEIGHT &&
                   (currentYPos === BOUNDARY_MARGIN_Y || currentYPos === bottomBoundary)) {
-                    // if (!d3.select(this).classed("fixed")) {
+                    if (!d3.select(this).classed("fixed")) {
                         height += OFFSET_VALUE;
                         boundingBoxContainer.attr("height", height);
                         link
@@ -1646,7 +1646,7 @@ export var drawGraph = function (workbook) {
                         node.attr("y", function (d) {
                             return d.y;
                         });
-                    // }
+                    }
                 }
                 return d.y = currentYPos;
             }).attr("transform", function (d) {

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1620,8 +1620,8 @@ export var drawGraph = function (workbook) {
             boundingBoxRect
                 .attr("x", -xTranslation / graphZoom + BOUNDARY_MARGIN_X_L / 2)
                 .attr("width", width / graphZoom - BOUNDARY_MARGIN_X_R)
-                .attr("y", -yTranslation / graphZoom + BOUNDARY_MARGIN_Y_T)
-                .attr("height", height / graphZoom - BOUNDARY_MARGIN_Y_B / 2);
+                .attr("y", -yTranslation / graphZoom + BOUNDARY_MARGIN_Y_T / 2)
+                .attr("height", height / graphZoom - BOUNDARY_MARGIN_Y_B);
         }
 
         // this controls movement and position of nodes, clamps the nodes to boundary

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -230,8 +230,6 @@ export var drawGraph = function (workbook) {
 
     var flexibleContainerRect = boundingBoxContainer.append("rect")
         .attr("class", "boundingBox")
-        .attr("stroke", "black")
-        .attr("stroke-width", 1)
         .attr("fill", "none")
         .attr("id", "flexibleContainerRect");
 
@@ -262,10 +260,6 @@ export var drawGraph = function (workbook) {
     let xTranslation = 0;
     let yTranslation = 0;
     let flexibleContainer = null;
-
-    function getXTranslation() {
-        return xTranslation;
-    }
 
     function updateZoomContainerInfo() {
         // transform attribute of zoomContainer contains translation info about graph
@@ -355,12 +349,11 @@ export var drawGraph = function (workbook) {
     let zoomScaleSliderLeft;
     let zoomScaleSliderRight;
     let prevGrnstateZoomVal;
-    let centerXCoord;
-    let centerYCoord;
 
     const updateAppBasedOnZoomValue = () => {
         let zoomDisplay;
 
+        // If the zoom value is out of bounds, reset it to the previous value.
         if (adaptive) {
             zoomDisplay = grnState.zoomValue
         } else if (!adaptive && flexZoomInBounds((grnState.zoomValue <= ZOOM_DISPLAY_MIDDLE ? zoomScaleLeft : zoomScaleRight)(grnState.zoomValue)) ) {
@@ -391,8 +384,6 @@ export var drawGraph = function (workbook) {
             if (!adaptive) {
                 center();
                 updateZoomContainerInfo();
-                centerXCoord = xTranslation;
-                centerYCoord = yTranslation;
             }
 
             $(ZOOM_SLIDER).val(
@@ -507,11 +498,10 @@ export var drawGraph = function (workbook) {
             width = $container.width();
             height = $container.height();
             // put a border with a gray stroke around the original container size
-            d3.select("rect").attr("stroke", "#9A9A9A")
-                .attr("width", width)
-                .attr("height", height);
+            d3.select("rect")
+              .attr("width", width)
+              .attr("height", height);
             $(".boundingBox").attr("width", width).attr("height", height);
-            d3.select("#flexibleContainerRect").attr("stroke", "black");
             center();
         }
         updateAppBasedOnZoomValue(); // Update zoom value within bounds
@@ -1497,7 +1487,7 @@ export var drawGraph = function (workbook) {
         const BOUNDARY_MARGIN_Y_T = getBOUNDARY_MARGIN_Y_T();
         minX = minX < BOUNDARY_MARGIN_X_L ? BOUNDARY_MARGIN_X_L : minX;
         minY = minY < BOUNDARY_MARGIN_Y_T ? BOUNDARY_MARGIN_Y_T : minY;
-        
+
         maxX =
           maxX > -xTranslation / graphZoom + BOUNDARY_MARGIN / 2 + width / graphZoom - BOUNDARY_MARGIN
             ? -xTranslation / graphZoom + BOUNDARY_MARGIN / 2 + width / graphZoom - BOUNDARY_MARGIN
@@ -1511,7 +1501,7 @@ export var drawGraph = function (workbook) {
         let flexiBoxWidth = maxX - minX;
         if (maxX < 0 && minX < 0) {
             flexiBoxWidth = Math.abs(maxX) - Math.abs(minX);
-        } 
+        }
 
         let flexiBoxHeight = maxY - minY;
         if (maxY < 0 && minY < 0) {
@@ -1538,7 +1528,7 @@ export var drawGraph = function (workbook) {
                 return false;
             }
         }
-        return true
+        return true;
     }
 
     // only calculate Left and Top boundary margins because calculate rightboundary and bottomboundary in tick
@@ -1572,17 +1562,6 @@ export var drawGraph = function (workbook) {
 
         if (!adaptive) {
             flexibleContainer = calcFlexiBox();
-
-            const flexDimensions = `
-                width ${Math.round(flexibleContainerRect.attr("width"))}
-                x ${Math.round(flexibleContainerRect.attr("x"))}
-                maxX ${Math.round(flexibleContainer.maxX)}
-                height ${Math.round(flexibleContainerRect.attr("height"))}
-                y ${Math.round(flexibleContainerRect.attr("y"))}
-                maxY ${Math.round(flexibleContainer.maxY)}
-                `;
-            $("#flexiBox-dimensions").text(flexDimensions);
-
 
             flexibleContainerRect
               .attr("x", flexibleContainer.x)

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -13,6 +13,7 @@ import {
     ZOOM_ADAPTIVE_MAX_SCALE,
     NETWORK_GRN_MODE
 } from "./constants";
+import { max } from "moment";
 
 /* globals d3 */
 /* eslint-disable no-use-before-define, func-style */
@@ -1506,7 +1507,20 @@ export var drawGraph = function (workbook) {
         maxX = maxX > $container.width() ? $container.width() - BOUNDARY_MARGIN_X_R : maxX;
         minY = minY < BOUNDARY_MARGIN_Y_T ? BOUNDARY_MARGIN_Y_T : minY;
         maxY = maxY > $container.height() ? $container.height() - BOUNDARY_MARGIN_Y_B : maxY;
-        return {x: minX, y: minY, width: maxX - minX, height: maxY - minY, maxX: maxX, maxY: maxY};
+        // console.log("flexi box width and height", maxX - minX, "maxX", maxX, "minX", minX, "maxY - minY", maxY - minY, "maxY", maxY, "minY", minY)
+        let width = 1234;
+        if (maxX < 0 && minX < 0) {
+            width = Math.abs(maxX) - Math.abs(minX);
+        } else {
+            width = maxX - minX;
+        }
+        let height = 1234;
+        if (maxY < 0 && minY < 0) {
+            height = Math.abs(maxY) - Math.abs(minY);
+        } else {
+            height = maxY - minY;
+        }
+        return {x: minX, y: minY, maxX: maxX, maxY: maxY, width: width, height: height};
     }
 
     // this checks if zoomInValue is in bounds when zoom in and out
@@ -1590,9 +1604,7 @@ export var drawGraph = function (workbook) {
                 boundX
                 ${Math.round(BOUNDARY_MARGIN_X_L)}
                 ${Math.round(BOUNDARY_MARGIN_X_R)}
-            */
-            const flexDimensions = `
-                 yTrnslt
+                yTrnslt
                 ${Math.round(yTranslation)}
                 flx.y
                 ${Math.round(flexibleContainer.y)}
@@ -1601,13 +1613,14 @@ export var drawGraph = function (workbook) {
                 boundY
                 ${Math.round(BOUNDARY_MARGIN_Y_T)}
                 ${Math.round(BOUNDARY_MARGIN_Y_B)}
-                flx.x
-                ${Math.round(flexibleContainer.x)}
-                flx.w
-                ${Math.round(flexibleContainer.width)}
-                boundX
-                ${Math.round(BOUNDARY_MARGIN_X_L)}
-                ${Math.round(BOUNDARY_MARGIN_X_R)}
+            */
+            const flexDimensions = `
+                width ${Math.round(flexibleContainerRect.attr("width"))}
+                x ${Math.round(flexibleContainerRect.attr("x"))}
+                maxX ${Math.round(flexibleContainer.maxX)}
+                height ${Math.round(flexibleContainerRect.attr("height"))}
+                y ${Math.round(flexibleContainerRect.attr("y"))}
+                maxY ${Math.round(flexibleContainer.maxY)}
                 `;
             $("#flexiBox-dimensions").text(flexDimensions);
 

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -268,7 +268,9 @@ export var drawGraph = function (workbook) {
 
     function inBounds(graphZoom, dx, dy, dPad) {
         updateZoomContainerInfo();
-        console.log("dx", dx, "dy", dy, "yTranslation", yTranslation)
+        console.log("dx", dx, "flexibleContainer.x", flexibleContainer.x, "xTranslation", xTranslation, "viewport height", height)
+        console.log("dy", dy, "flexibleContainer.y", flexibleContainer.y, "yTranslation", yTranslation, "viewport width", width)
+        console.log(" ")
 
         if (
           ((dx < 0 || xTranslation < 0) &&
@@ -1432,9 +1434,9 @@ export var drawGraph = function (workbook) {
                 if (controlPoints) {
                     if (controlPoints.includes("A")) {
                         const splitSpaces = controlPoints.split(" ");
-                        const controlPoint = splitSpaces[0].split("M")[1].split(",");
-                        const controlPointX = controlPoint[0];
-                        const controlPointY = controlPoint[1];
+                        const controlPointXY = splitSpaces[2].split(",")
+                        const controlPointX = controlPointXY[0];
+                        const controlPointY = controlPointXY[1];
                         xValuesPaths.push(parseFloat(controlPointX))
                         yValuesPaths.push(parseFloat(controlPointY))
                     }

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1424,14 +1424,28 @@ export var drawGraph = function (workbook) {
 
             // const xValuesPaths = paths.map((path) => path.label.x);
             // const yValuesPaths = paths.map((path) => path.label.y);
+            let xValuesPaths = []
+            let yValuesPaths = []
+            link.selectAll("path").attr("d", (pathData) => {
+                if (pathData.label) {
+                    // have to make sure paths are rendered before reading label
+                    // console.log(pathData.label.x)
+                    xValuesPaths.push(pathData.label.x)
+                    yValuesPaths.push(pathData.label.y)
+                    // console.log(pathData.label.y)
+                } 
+            })
+            // let xValuesPaths = paths.map(path => console.log(path))
+
+            // console.log(xValuesPaths, yValuesPaths)
 
             const xValuesNodes = nodes.map((node) => node.x);
             const yValuesNodes = nodes.map((node) => node.y);
 
-            // const xValues = xValuesPaths.concat(xValuesNodes);
-            // const yValues = yValuesPaths.concat(yValuesNodes);
-            const xValues = xValuesNodes
-            const yValues = yValuesNodes
+            const xValues = xValuesPaths.concat(xValuesNodes);
+            const yValues = yValuesPaths.concat(yValuesNodes);
+            // const xValues = xValuesNodes
+            // const yValues = yValuesNodes
 
             const minX = Math.min(...xValues);
             const minY = Math.min(...yValues);
@@ -1469,17 +1483,18 @@ export var drawGraph = function (workbook) {
         var MAX_HEIGHT = 5000;
         var OFFSET_VALUE = 5;
 
+        if (!adaptive) {
+            flexibleContainer = calcFlexiBox(nodes);
+
+            flexibleContainerRect
+                .attr("x", flexibleContainer.x)
+                .attr("y", flexibleContainer.y)
+                .attr("width", flexibleContainer.width)
+                .attr("height", flexibleContainer.height);
+        }
+
         // this controls movement and position of nodes
         try {
-            if (!adaptive) {
-                flexibleContainer = calcFlexiBox(nodes);
-
-                flexibleContainerRect
-                    .attr("x", flexibleContainer.x)
-                    .attr("y", flexibleContainer.y)
-                    .attr("width", flexibleContainer.width)
-                    .attr("height", flexibleContainer.height);
-            }
             node.attr("x", function (d) {
                 var selfReferringEdge = getSelfReferringEdge(d);
 

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -175,6 +175,7 @@ export var drawGraph = function (workbook) {
             var string = zoomContainer.attr("transform");
             scale = 1 / +(string.match(/scale\(([^\)]+)\)/)[1]);
         }
+        // TODO: instead of d3.event.x >= ZOOM_DISPLAY_MIDDLE, need to make sure that box in bounds
         if (!adaptive && d3.event.x >= ZOOM_DISPLAY_MIDDLE ) {
             if (inBounds(d3.event.dx, d3.event.dy)) {
                 zoom.translateBy(
@@ -212,14 +213,15 @@ export var drawGraph = function (workbook) {
         .attr("width", width)
         .attr("height", height);
 
-    var boundingBoxContainer = zoomContainer.append("g"); // appended another g here...
+    var boundingBoxContainer = zoomContainer.append("g")
+        .attr("stroke", "black")
+        .attr("stroke-width", 1); // appended another g here...
 
     var flexibleContainerRect = boundingBoxContainer.append("rect")
         .attr("class", "boundingBox")
         .attr("stroke", "black")
         .attr("stroke-width", 1)
         .attr("fill", "none")
-        // .append("g")
 
     var zoom = d3.zoom()
         .scaleExtent([MIN_SCALE, ZOOM_ADAPTIVE_MAX_SCALE])
@@ -320,9 +322,7 @@ export var drawGraph = function (workbook) {
 
     const updateAppBasedOnZoomValue = () => {
         // If !adaptive, set Zoomvalue to ZOOM_DISPLAY_MIDDLE, 100, so do not zoom outside graph
-        if (!adaptive && grnState.zoomValue < ZOOM_DISPLAY_MIDDLE) {
-            grnState.zoomValue = ZOOM_DISPLAY_MIDDLE;
-        }
+        // TODO: instead of d3.event.x >= ZOOM_DISPLAY_MIDDLE, need to make sure that box in bounds
 
         const zoomDisplay = grnState.zoomValue;
         if (adaptive) {
@@ -331,7 +331,9 @@ export var drawGraph = function (workbook) {
                 ? zoomScaleLeft
                 : zoomScaleRight)(zoomDisplay)
             );
-        } else if (!adaptive && grnState.zoomValue >= ZOOM_DISPLAY_MIDDLE) {
+        }
+        // TODO: instead of d3.event.x >= ZOOM_DISPLAY_MIDDLE, need to make sure that box in bounds
+        else if (!adaptive) {
             setGraphZoom(
                 (zoomDisplay <= ZOOM_DISPLAY_MIDDLE
                 ? zoomScaleLeft
@@ -357,7 +359,9 @@ export var drawGraph = function (workbook) {
                 : zoomScaleSliderRight
               ).invert(finalDisplay)
             );
-        } else if (!adaptive && grnState.zoomValue >= ZOOM_DISPLAY_MIDDLE) {
+        }
+        // TODO: instead of d3.event.x >= ZOOM_DISPLAY_MIDDLE, need to make sure that box in bounds 
+        else if (!adaptive) {
             // only allow minimum zoom value to be 100% so that do not go outside of viewport
             $(ZOOM_SLIDER).val(
             (finalDisplay <= ZOOM_DISPLAY_MIDDLE

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -268,49 +268,51 @@ export var drawGraph = function (workbook) {
 
     function inBounds(graphZoom, dx, dy) {
         updateZoomContainerInfo();
+        // console.log("dy", dy, "flexibleContainer.y", flexibleContainer.y, "yTranslation", yTranslation, "viewport height", height)
+        // console.log("dx", dx, "flexibleContainer.x", flexibleContainer.x, "xTranslation", xTranslation, "viewport width", width)
+        // console.log(Math.abs(xTranslation) < flexibleContainer.x, !(Math.abs(xTranslation) * graphZoom - flexibleContainer.x > dx))
+        // handle left border of viewport
 
+        if ((Math.abs(xTranslation) * graphZoom - flexibleContainer.x > dx)) {
+            return false
+        }
+        if (Math.abs(yTranslation) * graphZoom - flexibleContainer.y > dy) {
+          return false;
+        }
+
+        // handle right border
         if (
-          ((dx < 0 || xTranslation < 0) &&
+          ((dx < 0 || (xTranslation < 0 && Math.abs(xTranslation) > flexibleContainer.x)) &&
               Math.abs(xTranslation) * graphZoom >=
-                Math.floor(flexibleContainer.x) + dx) && 
-                !(Math.abs(xTranslation) * graphZoom - flexibleContainer.x > dx) || (dx > 0 &&
+                Math.floor(flexibleContainer.x) + dx)
+                || (dx > 0 &&
           (flexibleContainer.width + 
             flexibleContainer.x + 
             xTranslation + 
             dx >=
             width / graphZoom))
         ) {
-            console.log("dx", dx, "flexibleContainer.x", flexibleContainer.x, "xTranslation", xTranslation, "viewport width", width)
-            return false;
-        } else if (
-            ((dy < 0 || yTranslation < 0) &&
+            return false
+        }
+
+        // handle bottom border
+        if (
+            ((dy < 0 || (yTranslation < 0 && Math.abs(yTranslation) > flexibleContainer.y)) &&
                 Math.abs(yTranslation) * graphZoom >=
-                    Math.floor(flexibleContainer.y) + dy) && 
-                        !(Math.abs(yTranslation) * graphZoom - flexibleContainer.y > dy) || (dy > 0 &&
-            (flexibleContainer.height +
+                    Math.floor(flexibleContainer.y) + dy) 
+            || (dy > 0 &&
+                (flexibleContainer.height +
                 flexibleContainer.y +
                 yTranslation +
                 dy >=
                 height / graphZoom))
         ) {
             console.log("yTranslation returned FALSE")
-            console.log("dy", dy, "flexibleContainer.y", flexibleContainer.y, "yTranslation", yTranslation, "viewport height", height)
-            console.log("first statement dy or y Translation", (dy < 0 || yTranslation < 0))
-            console.log("first truth move up", Math.abs(yTranslation) * graphZoom >=
-                    Math.floor(flexibleContainer.y + dy), Math.abs(yTranslation) * graphZoom, ">=", Math.floor(flexibleContainer.y + dy))
-            console.log("first statement move down", (flexibleContainer.height +
-                flexibleContainer.y +
-                yTranslation +
-                dy >=
-                height / graphZoom))
-            
             return false
-        } else {
-            // console.log("flexContainer.x",flexibleContainer.x,"flexContainer.width", flexibleContainer.width, "xTranslation", xTranslation, "total width", width);
-            console.log("flexContainer height and width in bounds");
-            return true
         }
-        
+        // console.log("flexContainer.x",flexibleContainer.x,"flexContainer.width", flexibleContainer.width, "xTranslation", xTranslation, "total width", width);
+        console.log("flexContainer height and width in bounds");
+        return true
     };
 
     // controls reading movement of zoomSlider and scaling graph to that zoomScale
@@ -1482,34 +1484,33 @@ export var drawGraph = function (workbook) {
     }
 
     function flexRectLimitBounds() {
-        let flexiBoxInBounds = true;
         if (flexibleContainer) {
             // x left bound
             if (flexibleContainer.x < 0) {
                 flexibleContainer.x = 0;
-                flexiBoxInBounds = false;
+                return false
             }
 
             // x right bound
             if (!(flexibleContainer.width - flexibleContainer.x  <= width * graphZoom)) {
                 flexibleContainer.width = (width - flexibleContainer.x) * graphZoom;
-                flexiBoxInBounds = false;
+                return false
             }
 
             // y top bound
             if (flexibleContainer.y < 0) {
                 flexibleContainer.y = 0;
-                flexiBoxInBounds = false;
+                return false
             }
             
             // y bottom bound
             if (!(flexibleContainer.height - flexibleContainer.y <= height * graphZoom)) {
                 flexibleContainer.height = (height - flexibleContainer.y) * graphZoom;
-                flexiBoxInBounds = false;
+                return false
             }
         }
 
-        return flexiBoxInBounds;
+        // return flexiBoxInBounds;
     }
 
     // Tick only runs while the graph physics are still running.

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -176,7 +176,7 @@ export var drawGraph = function (workbook) {
             scale = 1 / +(string.match(/scale\(([^\)]+)\)/)[1]);
         }
 
-        if (adaptive || (!adaptive && flexRectInBounds(graphZoom) && inBounds(graphZoom, d3.event.dx, d3.event.dy, false))) {
+        if (adaptive || (!adaptive && flexRectInBounds(graphZoom) && inBounds(graphZoom, d3.event.dx, d3.event.dy))) {
             zoom.translateBy(
                 zoomContainer,
                 scale * (d3.event.x - zoomDragPrevX),
@@ -266,40 +266,51 @@ export var drawGraph = function (workbook) {
             .split("(")[1].split(",")[1].split(")")[0]);
     };
 
-    function inBounds(graphZoom, dx, dy, dPad) {
+    function inBounds(graphZoom, dx, dy) {
         updateZoomContainerInfo();
-        console.log("dx", dx, "flexibleContainer.x", flexibleContainer.x, "xTranslation", xTranslation, "viewport height", height)
-        console.log("dy", dy, "flexibleContainer.y", flexibleContainer.y, "yTranslation", yTranslation, "viewport width", width)
-        console.log(" ")
 
         if (
           ((dx < 0 || xTranslation < 0) &&
               Math.abs(xTranslation) * graphZoom >=
-                Math.floor(flexibleContainer.x + dx)) ||
+                Math.floor(flexibleContainer.x) + dx) && 
+                !(Math.abs(xTranslation) * graphZoom - flexibleContainer.x > dx) || (dx > 0 &&
           (flexibleContainer.width + 
             flexibleContainer.x + 
             xTranslation + 
             dx >=
-            width / graphZoom)
+            width / graphZoom))
         ) {
-          return false;
+            console.log("dx", dx, "flexibleContainer.x", flexibleContainer.x, "xTranslation", xTranslation, "viewport width", width)
+            return false;
         } else if (
             ((dy < 0 || yTranslation < 0) &&
                 Math.abs(yTranslation) * graphZoom >=
-                    Math.floor(flexibleContainer.y + dy)) ||
+                    Math.floor(flexibleContainer.y) + dy) && 
+                        !(Math.abs(yTranslation) * graphZoom - flexibleContainer.y > dy) || (dy > 0 &&
             (flexibleContainer.height +
                 flexibleContainer.y +
                 yTranslation +
                 dy >=
-                height / graphZoom)
+                height / graphZoom))
         ) {
             console.log("yTranslation returned FALSE")
+            console.log("dy", dy, "flexibleContainer.y", flexibleContainer.y, "yTranslation", yTranslation, "viewport height", height)
+            console.log("first statement dy or y Translation", (dy < 0 || yTranslation < 0))
+            console.log("first truth move up", Math.abs(yTranslation) * graphZoom >=
+                    Math.floor(flexibleContainer.y + dy), Math.abs(yTranslation) * graphZoom, ">=", Math.floor(flexibleContainer.y + dy))
+            console.log("first statement move down", (flexibleContainer.height +
+                flexibleContainer.y +
+                yTranslation +
+                dy >=
+                height / graphZoom))
+            
             return false
+        } else {
+            // console.log("flexContainer.x",flexibleContainer.x,"flexContainer.width", flexibleContainer.width, "xTranslation", xTranslation, "total width", width);
+            console.log("flexContainer height and width in bounds");
+            return true
         }
-        // console.log("flexContainer.x",flexibleContainer.x,"flexContainer.width", flexibleContainer.width, "xTranslation", xTranslation, "total width", width);
-        console.log("flexContainer height and width in bounds");
-
-        return true
+        
     };
 
     // controls reading movement of zoomSlider and scaling graph to that zoomScale
@@ -313,8 +324,6 @@ export var drawGraph = function (workbook) {
         if (adaptive || (!adaptive && flexRectInBounds(graphZoom))) {
             zoom.scaleTo(container, zoomScale);
         }
-        
-        
     };
 
     // See setupZoomElements below to see how these are initialized. They are declared here because
@@ -507,19 +516,9 @@ export var drawGraph = function (workbook) {
         if (adaptive) {
             zoom.translateBy(zoomContainer, moveWidth, moveHeight);
         } else if (!adaptive) {
-            // if (inBounds(width, height) && flexRectInBounds(graphZoom)) {
-            if (flexRectInBounds(graphZoom) && inBounds(graphZoom, moveWidth, moveHeight, true)) {
+            if (flexRectInBounds(graphZoom) && inBounds(graphZoom, moveWidth, moveHeight)) {
                 zoom.translateBy(zoomContainer, moveWidth, moveHeight);
-            } 
-            // else if (inBounds(graphZoom, 0, 0)) {
-            //     // ^check if current position in bounds but still not at border,
-            //     // then move remaining amount left in graph
-            //     if (moveWidth !== 0 && inBounds(graphZoom, moveWidth / 3, moveHeight)) {
-            //         zoom.translateBy(zoomContainer, moveWidth / 3, moveHeight);
-            //     } else if (moveHeight !== 0 && inBounds(graphZoom, moveWidth, moveHeight / 3)) {
-            //         zoom.translateBy(zoomContainer, moveWidth, moveHeight / 3);
-            //     }
-            // }
+            }
         }
     }
 
@@ -1477,7 +1476,7 @@ export var drawGraph = function (workbook) {
                 return false;
             } else if (flexibleContainer.height * zoomValue > height) {
                 return false;
-            } 
+            }
         }
         return true
     }
@@ -1493,7 +1492,7 @@ export var drawGraph = function (workbook) {
 
             // x right bound
             if (!(flexibleContainer.width - flexibleContainer.x  <= width * graphZoom)) {
-                flexibleContainer.width = width - flexibleContainer.x;
+                flexibleContainer.width = (width - flexibleContainer.x) * graphZoom;
                 flexiBoxInBounds = false;
             }
 
@@ -1505,7 +1504,7 @@ export var drawGraph = function (workbook) {
             
             // y bottom bound
             if (!(flexibleContainer.height - flexibleContainer.y <= height * graphZoom)) {
-                flexibleContainer.height = height - flexibleContainer.y;
+                flexibleContainer.height = (height - flexibleContainer.y) * graphZoom;
                 flexiBoxInBounds = false;
             }
         }

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -272,32 +272,45 @@ export var drawGraph = function (workbook) {
             .split("(")[1].split(",")[1].split(")")[0]);
     };
 
-    // TODO: issue with this, might also have to do with boundaries of graph and clamping
-    // does not allow flexbox to go outside of container when move or drag, have to incorporate into tick somehow?
-    // NEED TO USE PREVIOUS POSITION
-    // let prevUpwardMoveViolated = false
-    // issue where if drag graph and then move with arrows, exceed bounds, has something to do with yTranslation since for some reason the old value is kept
-    // when use cursor, top and bottom bound are shifted up by same amount
     function exportBoundsMoveDrag(graphZoom, dx, dy, dPadMove) {
         updateZoomContainerInfo();
-        // console.log("dx", dx, dx * graphZoom, "flexibleContainer.x", flexibleContainer.x, "xTranslation", xTranslation, "viewport width", width)
-        console.log("dy", dy, dy * graphZoom, "flexibleContainer.y", flexibleContainer.y, "yTranslation", yTranslation, "viewport height", height)
-        // if (
-        //   ((dx < 0 || xTranslation < 0) &&
-        //     Math.abs(xTranslation) * graphZoom >=
-        //       Math.floor(flexibleContainer.x) + dx * graphZoom &&
-        //     !(Math.abs(xTranslation) * graphZoom - flexibleContainer.x > dx * graphZoom)) ||
-        //   (dx > 0 &&
-        //     flexibleContainer.width + flexibleContainer.x + xTranslation + dx * graphZoom >=
-        //       width / graphZoom)
-        // ) {
-        //   return false;
-        // } 
+        console.log("dx", dx, dx * graphZoom, "flexibleContainer.x", flexibleContainer.x, "xTranslation", xTranslation, "viewport width", width)
+        // console.log("dy", dy, dy * graphZoom, "flexibleContainer.y", flexibleContainer.y, "yTranslation", yTranslation, "viewport height", height)
+        // TODO: take away hardcoded 5 and use BOUNDARY_MARGIN instead
+        if (
+          (flexibleContainer.x <= 5 || xTranslation < 0) &&
+          Math.abs(xTranslation) >= Math.floor(flexibleContainer.x) &&
+          (dx < 0 ||
+            (dx > 0 &&
+              Math.abs(xTranslation) >= Math.floor(flexibleContainer.x) + dx))
+        ) {
+            console.log("2nd x statement false")
+          return false;
+        }
 
-        // TODO: this handles left border, but the graph still goes through the left edge
-        // console.log(!(Math.abs(xTranslation) < flexibleContainer.x), !(Math.abs(xTranslation) * graphZoom - flexibleContainer.x > dx));
+        if (
+          dPadMove &&
+          xTranslation < 0 &&
+          dx < 0 &&
+          Math.abs(xTranslation + dx) > flexibleContainer.x
+        ) {
+            console.log("3rd x statement false")
+          return false;
+        }
 
-        // this allows to move up and down from bottom border, but goes through top border
+        if (
+          dx > 0 &&
+          flexibleContainer.width +
+            flexibleContainer.x +
+            xTranslation +
+            dx * graphZoom >=
+            width / graphZoom
+        ) {
+            console.log("4th x statement false")
+          return false;
+        }
+
+        // Y-axis boundaries
         if (
           dy < 0 && Math.abs(yTranslation) * graphZoom >
             Math.floor(flexibleContainer.y) + dy * graphZoom
@@ -310,6 +323,7 @@ export var drawGraph = function (workbook) {
           return false;
         }
 
+        // TODO: take away hardcoded 5 and use BOUNDARY_MARGIN instead
         if ((flexibleContainer.y <= 5 ||
           yTranslation < 0) &&
           Math.abs(yTranslation) >= Math.floor(flexibleContainer.y) &&
@@ -330,7 +344,6 @@ export var drawGraph = function (workbook) {
             yTranslation +
             dy * graphZoom >=
             height / graphZoom) {
-                console.log("downward movement returning false")
             return false
         }
 

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -275,12 +275,10 @@ export var drawGraph = function (workbook) {
         updateZoomContainerInfo();
         // left border
         if (xTranslation < 0 &&
-          Math.abs(xTranslation) >= Math.floor(flexibleContainer.x) * graphZoom &&
-          (dx < 0 ||
-            (dx > 0 &&
-              Math.abs(xTranslation) >= Math.floor(flexibleContainer.x) * graphZoom + dx * graphZoom))
-        ) {
-            console.log("1st x statement false")
+              Math.abs(xTranslation) >=
+                Math.floor(flexibleContainer.x) * graphZoom + dx * graphZoom)
+         {
+          console.log("1st x statement false");
           return false;
         }
         
@@ -301,19 +299,6 @@ export var drawGraph = function (workbook) {
         }
 
         // Y-axis boundaries
-        // when moving graph up, prevents from graph from locking at bottom of viewport
-        if (dy < 0 && Math.abs(yTranslation) * graphZoom >
-            Math.floor(flexibleContainer.y) + dy * graphZoom
-           &&
-          !(
-            Math.abs(yTranslation) * graphZoom - flexibleContainer.y >
-            dy * graphZoom
-          )
-        ) {
-            console.log("first y statement false")
-            return false;
-        }
-
         // prevents graph from going through top border
         if (yTranslation < 0 &&
           Math.abs(yTranslation) >= Math.floor(flexibleContainer.y) * graphZoom &&

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -204,6 +204,17 @@ export var drawGraph = function (workbook) {
         .attr("height", height)
         .attr("id", "exportContainer");
 
+    var viewportBoundingBox = svg
+        .append("g")
+        .append("rect")
+        .attr("class", "boundingBox")
+        .attr("width", width)
+        .attr("height", height)
+        .style("fill", "none")
+        // .attr("stroke", "black")
+        // .attr("stroke-width", 2)
+        .attr("id", "viewportBoundingBox");
+
     var zoomContainer = svg.append("g") // required for zoom to work
         .attr("class", "boundingBox")
         .attr("width", width)

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -176,11 +176,7 @@ export var drawGraph = function (workbook) {
             scale = 1 / +(string.match(/scale\(([^\)]+)\)/)[1]);
         }
 
-        // console.log("scale", scale, "graphZoom", graphZoom)
-        // inBounds(d3.event.dx, d3.event.dy) && flexRectInBounds(graphZoom)
-
-        if (adaptive || (!adaptive && flexRectInBounds(graphZoom) && inBounds(graphZoom, d3.event.dx, d3.event.dy))) {
-        // if (adaptive || (!adaptive && inBounds(d3.event.dx, d3.event.dy) && flexRectInBounds(graphZoom))) {
+        if (adaptive || (!adaptive && flexRectInBounds(graphZoom) && inBounds(graphZoom, d3.event.dx, d3.event.dy, false))) {
             zoom.translateBy(
                 zoomContainer,
                 scale * (d3.event.x - zoomDragPrevX),
@@ -270,8 +266,9 @@ export var drawGraph = function (workbook) {
             .split("(")[1].split(",")[1].split(")")[0]);
     };
 
-    function inBounds(graphZoom, dx, dy) {
+    function inBounds(graphZoom, dx, dy, dPad) {
         updateZoomContainerInfo();
+        console.log("dx", dx, "dy", dy, "yTranslation", yTranslation)
         // if ((xTranslation < 0 && Math.abs(xTranslation) * graphZoom >= Math.floor(flexibleContainer.x + dx)) || 
         // (xTranslation > 0 && (flexibleContainer.width + flexibleContainer.x + xTranslation) + dx >= width / graphZoom)) {
         /*(xTranslation < 0 &&
@@ -279,26 +276,42 @@ export var drawGraph = function (workbook) {
               Math.abs(xTranslation) * graphZoom >=
                 Math.floor(flexibleContainer.x + dx)) ||
               flexibleContainer.width + flexibleContainer.x + Math.abs(xTranslation) >= width * graphZoom)) ||*/
+
+        if (dPad) {
+            // if () {
+                console.log("flexContainer.y", flexibleContainer.y, "flexibleContainer.height", 
+                flexibleContainer.height,"yTranslation",yTranslation, "dy", dy, "total height",height);
+            // } else {
+                console.log((yTranslation < 0 &&
+                Math.abs(yTranslation) * graphZoom >=
+                    Math.floor(flexibleContainer.y + dy)) ||
+            (yTranslation > 0 &&
+            flexibleContainer.height +
+                flexibleContainer.y +
+                yTranslation +
+                dy >=
+                height / graphZoom))
+                console.log("dPad violated")
+            // }
+            
+        }
+
         if (
           (xTranslation < 0 &&
               Math.abs(xTranslation) * graphZoom >=
                 Math.floor(flexibleContainer.x + dx)) ||
           (xTranslation > 0 &&
-            flexibleContainer.width + flexibleContainer.x + xTranslation + dx >=
-              width / graphZoom)
+            flexibleContainer.width + 
+            flexibleContainer.x + 
+            xTranslation + 
+            dx >=
+            width / graphZoom)
         ) {
-          console.log(
-            Math.abs(xTranslation) * graphZoom >=
-              Math.floor(flexibleContainer.x + dx),
-            xTranslation,
-            xTranslation * graphZoom,
-            flexibleContainer.x
-          );
           return false;
         } else if (
             (yTranslation < 0 &&
-            Math.abs(yTranslation) * graphZoom >=
-                Math.floor(flexibleContainer.y + dy)) ||
+                Math.abs(yTranslation) * graphZoom >=
+                    Math.floor(flexibleContainer.y + dy)) ||
             (yTranslation > 0 &&
             flexibleContainer.height +
                 flexibleContainer.y +
@@ -306,21 +319,9 @@ export var drawGraph = function (workbook) {
                 dy >=
                 height / graphZoom)
         ) {
-            // validations for up/down cursor drag and movement
-            console.log(
-            "flexContainer.y",
-            flexibleContainer.y,
-            "flexibleContainer.height",
-            flexibleContainer.height,
-            "yTranslation",
-            yTranslation,
-            "total height",
-            height
-            );
-            console.log(" ");
             return false
         }
-        console.log("flexContainer.x",flexibleContainer.x,"flexContainer.width", flexibleContainer.width, "xTranslation", xTranslation, "total width", width);
+        // console.log("flexContainer.x",flexibleContainer.x,"flexContainer.width", flexibleContainer.width, "xTranslation", xTranslation, "total width", width);
         console.log("flexContainer height and width in bounds");
 
         return true
@@ -526,22 +527,22 @@ export var drawGraph = function (workbook) {
 
     // move: moves graph with D-pad
     function move (direction) {
-        var width = direction === "left" ? -50 : direction === "right" ? 50 : 0;
-        var height = direction === "up" ? -50 : direction === "down" ? 50 : 0;
+        var moveWidth = direction === "left" ? -50 : direction === "right" ? 50 : 0;
+        var moveHeight = direction === "up" ? -50 : direction === "down" ? 50 : 0;
         if (adaptive) {
-            zoom.translateBy(zoomContainer, width, height);
+            zoom.translateBy(zoomContainer, moveWidth, moveHeight);
         } else if (!adaptive) {
             // if (inBounds(width, height) && flexRectInBounds(graphZoom)) {
-            if (flexRectInBounds(graphZoom)) {
-                zoom.translateBy(zoomContainer, width, height);
+            if (flexRectInBounds(graphZoom) && inBounds(graphZoom, moveWidth, moveHeight, true)) {
+                zoom.translateBy(zoomContainer, moveWidth, moveHeight);
             } 
-            // else if (inBounds(0, 0)) {
+            // else if (inBounds(graphZoom, 0, 0)) {
             //     // ^check if current position in bounds but still not at border,
             //     // then move remaining amount left in graph
-            //     if (width !== 0 && inBounds(width / graphZoom / 3, height)) {
-            //         zoom.translateBy(zoomContainer, width / graphZoom / 3, height);
-            //     } else if (height !== 0 && inBounds(width, height / graphZoom / 3)) {
-            //         zoom.translateBy(zoomContainer, width, height / graphZoom / 3);
+            //     if (moveWidth !== 0 && inBounds(graphZoom, moveWidth / 3, moveHeight)) {
+            //         zoom.translateBy(zoomContainer, moveWidth / 3, moveHeight);
+            //     } else if (moveHeight !== 0 && inBounds(graphZoom, moveWidth, moveHeight / 3)) {
+            //         zoom.translateBy(zoomContainer, moveWidth, moveHeight / 3);
             //     }
             // }
         }

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -269,39 +269,12 @@ export var drawGraph = function (workbook) {
     function inBounds(graphZoom, dx, dy, dPad) {
         updateZoomContainerInfo();
         console.log("dx", dx, "dy", dy, "yTranslation", yTranslation)
-        // if ((xTranslation < 0 && Math.abs(xTranslation) * graphZoom >= Math.floor(flexibleContainer.x + dx)) || 
-        // (xTranslation > 0 && (flexibleContainer.width + flexibleContainer.x + xTranslation) + dx >= width / graphZoom)) {
-        /*(xTranslation < 0 &&
-            ((graphZoom <= 1 &&
-              Math.abs(xTranslation) * graphZoom >=
-                Math.floor(flexibleContainer.x + dx)) ||
-              flexibleContainer.width + flexibleContainer.x + Math.abs(xTranslation) >= width * graphZoom)) ||*/
-
-        if (dPad) {
-            // if () {
-                console.log("flexContainer.y", flexibleContainer.y, "flexibleContainer.height", 
-                flexibleContainer.height,"yTranslation",yTranslation, "dy", dy, "total height",height);
-            // } else {
-                console.log((yTranslation < 0 &&
-                Math.abs(yTranslation) * graphZoom >=
-                    Math.floor(flexibleContainer.y + dy)) ||
-            (yTranslation > 0 &&
-            flexibleContainer.height +
-                flexibleContainer.y +
-                yTranslation +
-                dy >=
-                height / graphZoom))
-                console.log("dPad violated")
-            // }
-            
-        }
 
         if (
-          (xTranslation < 0 &&
+          ((dx < 0 || xTranslation < 0) &&
               Math.abs(xTranslation) * graphZoom >=
                 Math.floor(flexibleContainer.x + dx)) ||
-          (xTranslation > 0 &&
-            flexibleContainer.width + 
+          (flexibleContainer.width + 
             flexibleContainer.x + 
             xTranslation + 
             dx >=
@@ -309,16 +282,16 @@ export var drawGraph = function (workbook) {
         ) {
           return false;
         } else if (
-            (yTranslation < 0 &&
+            ((dy < 0 || yTranslation < 0) &&
                 Math.abs(yTranslation) * graphZoom >=
                     Math.floor(flexibleContainer.y + dy)) ||
-            (yTranslation > 0 &&
-            flexibleContainer.height +
+            (flexibleContainer.height +
                 flexibleContainer.y +
                 yTranslation +
                 dy >=
                 height / graphZoom)
         ) {
+            console.log("yTranslation returned FALSE")
             return false
         }
         // console.log("flexContainer.x",flexibleContainer.x,"flexContainer.width", flexibleContainer.width, "xTranslation", xTranslation, "total width", width);
@@ -1499,24 +1472,8 @@ export var drawGraph = function (workbook) {
             updateZoomContainerInfo();
             // validations for zoom and left/right cursor drag and D-pad movement
             if (flexibleContainer.width * zoomValue > width ) {
-                console.log(
-                  "width exceeds",
-                  flexibleContainer.width * zoomValue,
-                  "total width",
-                  width,
-                  "graphZoom",
-                  graphZoom,
-                  "zoomValue",
-                  zoomValue
-                );
                 return false;
             } else if (flexibleContainer.height * zoomValue > height) {
-                console.log(
-                  "height exceeds",
-                  flexibleContainer.height * zoomValue,
-                  "total height",
-                  height
-                );
                 return false;
             } 
         }

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -176,7 +176,7 @@ export var drawGraph = function (workbook) {
             scale = 1 / +(string.match(/scale\(([^\)]+)\)/)[1]);
         }
         // TODO: instead of d3.event.x >= ZOOM_DISPLAY_MIDDLE, need to make sure that box in bounds
-        if (adaptive && (!adaptive && inBounds(d3.event.dx, d3.event.dy))) {
+        if (adaptive || (!adaptive && inBounds(d3.event.dx, d3.event.dy))) {
             zoom.translateBy(
                 zoomContainer,
                 scale * (d3.event.x - zoomDragPrevX),
@@ -1541,8 +1541,6 @@ export var drawGraph = function (workbook) {
                         });
                     }
                 }
-                // height += OFFSET_VALUE;
-                // boundingBoxContainer.attr("height", height);
                 return d.y = currentYPos;
             }).attr("transform", function (d) {
                 return "translate(" + d.x + "," + d.y + ")";

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -308,9 +308,9 @@ export var drawGraph = function (workbook) {
         var container = zoomContainer;
         // graphZoom is used in inBounds(width, height) to check if graph in zoomContainer when restricted to viewport
         graphZoom = zoomScale;
-        var nextZoomValue = graphZoom + 0.25;
-        console.log("graphZoom", graphZoom, "nextZoomValue", nextZoomValue)
-        if (adaptive || (!adaptive && flexRectInBounds(nextZoomValue, width / flexibleContainerRect.attr("width")))) {
+        // var nextZoomValue = graphZoom + 0.25;
+        // console.log("graphZoom", graphZoom, "nextZoomValue", nextZoomValue)
+        if (adaptive || (!adaptive && flexRectInBounds(graphZoom))) {
             zoom.scaleTo(container, zoomScale);
         }
         
@@ -327,21 +327,18 @@ export var drawGraph = function (workbook) {
     const updateAppBasedOnZoomValue = () => {
         // If !adaptive, set Zoomvalue to ZOOM_DISPLAY_MIDDLE, 100, so do not zoom outside graph
         // TODO: instead of d3.event.x >= ZOOM_DISPLAY_MIDDLE, need to make sure that box in bounds
-        let nextZoomValue = (grnState.zoomValue + 6 <= ZOOM_DISPLAY_MIDDLE ? zoomScaleLeft : zoomScaleRight)(grnState.zoomValue + 6);
-        let maxZoomValue = 2;
-        console.log(width, flexibleContainerRect.attr("width"));
-        if (!adaptive && flexibleContainer) {
-            flexibleContainer = calcFlexiBox()
-            maxZoomValue = width / flexibleContainerRect.attr("width");
+
+        let zoomDisplay;
+
+        if (adaptive) {
+            zoomDisplay = grnState.zoomValue
+        } else if (!adaptive && flexRectInBounds((grnState.zoomValue <= ZOOM_DISPLAY_MIDDLE ? zoomScaleLeft : zoomScaleRight)(grnState.zoomValue)) ) {
+            zoomDisplay = grnState.zoomValue;
+        } else {
+            console.log("statement false")
+            grnState.zoomValue = prevGrnstateZoomVal;
+            zoomDisplay = grnState.zoomValue;
         }
-
-        const zoomDisplay = grnState.zoomValue;
-
-        // if (!adaptive && !flexRectInBounds(nextZoomValue, maxZoomValue) && prevGrnstateZoomVal) {
-        //     grnState.zoomValue = prevGrnstateZoomVal
-        // }
-
-        
 
         console.log(
           "zoomDisplay",
@@ -349,12 +346,7 @@ export var drawGraph = function (workbook) {
           "set graphzoom value",
           (zoomDisplay <= ZOOM_DISPLAY_MIDDLE ? zoomScaleLeft : zoomScaleRight)(
             zoomDisplay
-          ),
-          "nextZoomValue",
-          nextZoomValue,
-          flexRectInBounds(nextZoomValue, maxZoomValue),
-          "maxZoomValue",
-          maxZoomValue
+          )
         );
 
         setGraphZoom(
@@ -1495,13 +1487,14 @@ export var drawGraph = function (workbook) {
         return {x: minX, y: minY, width: maxX - minX, height: maxY - minY};
     }
 
-    function flexRectInBounds(nextZoom, maxZoomValue) {
+    function flexRectInBounds(zoomValue) {
         if (flexibleContainer) {
-            if (nextZoom > maxZoomValue) {
-                return false
-            } else if (flexibleContainer.width * nextZoom > width) {
+            if (flexibleContainer.width * zoomValue > width) {
+                console.log(flexibleContainer.width, zoomValue, width, flexibleContainer.width * zoomValue > width);
+                console.log("width exceeds")
                 return false;
-            } else if (flexibleContainer.height * nextZoom > height) {
+            } else if (flexibleContainer.height * zoomValue > height) {
+                console.log("height exceeds")
                 return false;
             }
         }

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -273,8 +273,6 @@ export var drawGraph = function (workbook) {
 
     function viewportBoundsMoveDrag(graphZoom, dx, dy, dPadMove) {
         updateZoomContainerInfo();
-        console.log("dx", dx, dx * graphZoom, "flexContainer.x", flexibleContainer.x, "flexContainer.width", flexibleContainer.width, "xTranslation", xTranslation, "viewport width", width)
-        // console.log("dy", dy, dy * graphZoom, "flexibleContainer.y", flexibleContainer.y, "yTranslation", yTranslation, "viewport height", height)
         // left border
         if (xTranslation < 0 &&
           Math.abs(xTranslation) >= Math.floor(flexibleContainer.x) * graphZoom &&
@@ -298,36 +296,12 @@ export var drawGraph = function (workbook) {
         }
 
         // right border
-        if (graphZoom >= 1) {
-            if (dx > 0 &&
-            flexibleContainer.width +
-                flexibleContainer.x +
-                xTranslation +
-                dx * graphZoom >=
-                width / graphZoom
-            ) {
-                console.log("4th x statement false")
-                return false;
-            }
-        } else {
-            // this is somewhat of a solution, still a white gap sometimes
-            if (
-              dx > 0 &&
-              (flexibleContainer.width +
-                flexibleContainer.x +
-                xTranslation +
-                dx * graphZoom) + flexibleContainer.x * graphZoom >=
-                width / graphZoom
-            ) {
-              console.log("4th x statement false");
-              return false;
-            }
-
+        if (xTranslation + dx > width - (graphZoom * flexibleContainer.width + graphZoom * flexibleContainer.x)) {
+            return false
         }
-        
 
         // Y-axis boundaries
-        // moving up, prevents from graph locking at bottom of viewport
+        // when moving graph up, prevents from graph from locking at bottom of viewport
         if (dy < 0 && Math.abs(yTranslation) * graphZoom >
             Math.floor(flexibleContainer.y) + dy * graphZoom
            &&
@@ -336,31 +310,33 @@ export var drawGraph = function (workbook) {
             dy * graphZoom
           )
         ) {
-          return false;
+            console.log("first y statement false")
+            return false;
         }
 
+        // prevents graph from going through top border
         if (yTranslation < 0 &&
-          Math.abs(yTranslation) >= Math.floor(flexibleContainer.y) &&
+          Math.abs(yTranslation) >= Math.floor(flexibleContainer.y) * graphZoom &&
           (dy < 0 ||
             (dy > 0 &&
-              Math.abs(yTranslation) >= Math.floor(flexibleContainer.y) + dy ))
+              Math.abs(yTranslation) >= Math.floor(flexibleContainer.y) + dy * graphZoom))
         ) {
-          return false;
+            console.log("second y statement false")
+            return false;
         }
 
+        // moving up with dPad
         if (dPadMove && yTranslation < 0 && dy < 0 && Math.abs(yTranslation + dy) > flexibleContainer.y) {
+            console.log("third y statement false")
             return false
         }
         
-        if (dy > 0 &&
-        flexibleContainer.height +
-            flexibleContainer.y +
-            yTranslation +
-            dy * graphZoom >=
-            height / graphZoom) {
+        // bottom border
+        if (yTranslation + dy > height - (graphZoom * flexibleContainer.height + graphZoom * flexibleContainer.y)) {
+            console.log("hard coded y statement retuning false")
             return false
         }
-
+        
         return true
     };
 
@@ -370,10 +346,9 @@ export var drawGraph = function (workbook) {
             $container.removeClass(CURSOR_CLASSES).addClass("cursorGrab");
         }
         var container = zoomContainer;
-        // graphZoom is current zoom of
-        graphZoom = zoomScale;
         if (adaptive || (!adaptive && flexRectInBounds(graphZoom))) {
             zoom.scaleTo(container, zoomScale);
+            graphZoom = zoomScale
         }
     };
 
@@ -383,7 +358,7 @@ export var drawGraph = function (workbook) {
     let zoomScaleSliderLeft;
     let zoomScaleSliderRight;
     let prevGrnstateZoomVal;
-    let centerXCoord;
+    // let centerXCoord;
 
     const updateAppBasedOnZoomValue = () => {
         let zoomDisplay;
@@ -420,7 +395,6 @@ export var drawGraph = function (workbook) {
             if (!adaptive) {
                 center();
                 updateZoomContainerInfo();
-                centerXCoord = xTranslation
             }
 
             $(ZOOM_SLIDER).val(

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1409,17 +1409,24 @@ export var drawGraph = function (workbook) {
     var nodes = simulation.nodes()
 
     function calcFlexiBox (nodes) {
+        // let nodeHeight = 0
+        // let height = 0
+        // if (nodes.length > 0) {
+        //     width = nodes[0].width
+        //     height = nodes[0].height
+        // }
         const xValues = nodes.map(node => node.x)
         const yValues = nodes.map(node => node.y)
         const minX = Math.min(...xValues)
         const minY = Math.min(...yValues)
         const maxX = Math.max(...xValues)
-        const maxY = Math.max(...yValues)
+        const maxY = Math.max(...yValues) + nodeHeight
 
         return {x: minX, y: minY, width: maxX - minX, height: maxY - minY}
     }
 
-    let flexibleContainer = calcFlexiBox(nodes)
+    // don't set flexibleContainer = calcFlexiBox or else the function does not stop running, only want to run on tick
+    let flexibleContainer = null
     
     // Tick only runs while the graph physics are still running.
     // (I.e. when the graph is completely relaxed, tick stops running.)

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1409,19 +1409,17 @@ export var drawGraph = function (workbook) {
     var nodes = simulation.nodes()
 
     function calcFlexiBox (nodes) {
-        // let nodeHeight = 0
-        // let height = 0
-        // if (nodes.length > 0) {
-        //     width = nodes[0].width
-        //     height = nodes[0].height
-        // }
+        let nodeWidth = 0
+        if (nodes.length > 0) {
+            nodeWidth = nodes[0].textWidth + 8
+        }
         const xValues = nodes.map(node => node.x)
         const yValues = nodes.map(node => node.y)
         const minX = Math.min(...xValues)
         const minY = Math.min(...yValues)
-        const maxX = Math.max(...xValues)
+    
+        const maxX = Math.max(...xValues) + nodeWidth
         const maxY = Math.max(...yValues) + nodeHeight
-
         return {x: minX, y: minY, width: maxX - minX, height: maxY - minY}
     }
 
@@ -1447,13 +1445,15 @@ export var drawGraph = function (workbook) {
         var MAX_HEIGHT = 5000;
         var OFFSET_VALUE = 5;
 
-        flexibleContainer = calcFlexiBox(nodes);
+        if (!adaptive) {
+            flexibleContainer = calcFlexiBox(nodes);
 
-        flexibleContainerRect
-            .attr("x", flexibleContainer.x)
-            .attr("y", flexibleContainer.y)
-            .attr("width", flexibleContainer.width)
-            .attr("height", flexibleContainer.height)
+            flexibleContainerRect
+                .attr("x", flexibleContainer.x)
+                .attr("y", flexibleContainer.y)
+                .attr("width", flexibleContainer.width)
+                .attr("height", flexibleContainer.height)
+        }
 
         // this controls movement and position of nodes
         try {

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -279,7 +279,6 @@ export var drawGraph = function (workbook) {
               Math.abs(xTranslation) >=
                 Math.floor(flexibleContainer.x) * graphZoom + dx * graphZoom)
          {
-          console.log("1st x statement false");
           return false;
         }
         
@@ -290,7 +289,6 @@ export var drawGraph = function (workbook) {
           dx < 0 &&
           Math.abs(xTranslation + dx) > flexibleContainer.x * graphZoom
         ) {
-            console.log("3rd x statement false")
           return false;
         }
 
@@ -341,7 +339,7 @@ export var drawGraph = function (workbook) {
     let zoomScaleSliderLeft;
     let zoomScaleSliderRight;
     let prevGrnstateZoomVal;
-    // let centerXCoord;
+    let centerXCoord;
 
     const updateAppBasedOnZoomValue = () => {
         let zoomDisplay;
@@ -378,6 +376,7 @@ export var drawGraph = function (workbook) {
             if (!adaptive) {
                 center();
                 updateZoomContainerInfo();
+                centerXCoord = xTranslation
             }
 
             $(ZOOM_SLIDER).val(
@@ -1438,46 +1437,45 @@ export var drawGraph = function (workbook) {
         let xValuesPaths = []
         let yValuesPaths = []
 
-        link.selectAll("path").each( function(pathData) {
-            if (pathData.source) {
-                // Log the "d" attribute for each path
-                const controlPoints = d3.select(this).attr("d");
-                if (controlPoints) {
-                    if (controlPoints.includes("A")) {
-                        const splitSpaces = controlPoints.split(" ");
-                        const controlPointXY = splitSpaces[2].split(",")
-                        const controlPointX = controlPointXY[0];
-                        const controlPointY = controlPointXY[1];
-                        xValuesPaths.push(parseFloat(controlPointX))
-                        yValuesPaths.push(parseFloat(controlPointY))
-                    }
-                    else if (controlPoints.includes("C")) {
-                        const splitC = controlPoints.split("C");
+        // link.selectAll("path").each( function(pathData) {
+        //     if (pathData.source) {
+        //         // Log the "d" attribute for each path
+        //         const controlPoints = d3.select(this).attr("d");
+        //         if (controlPoints) {
+        //             if (controlPoints.includes("A")) {
+        //                 const splitSpaces = controlPoints.split(" ");
+        //                 const controlPointXY = splitSpaces[2].split(",")
+        //                 const controlPointX = controlPointXY[0];
+        //                 const controlPointY = controlPointXY[1];
+        //                 xValuesPaths.push(parseFloat(controlPointX))
+        //                 yValuesPaths.push(parseFloat(controlPointY))
+        //             }
+        //             else if (controlPoints.includes("C")) {
+        //                 const splitC = controlPoints.split("C");
 
-                        splitC[1].split(",").forEach((coordinates) => {
-                            const splitSpaces = coordinates.split(" ");
-                            const xValue = splitSpaces[splitSpaces.length - 2];
-                            const yValue = splitSpaces[splitSpaces.length - 1];
-                            xValuesPaths.push(parseFloat(xValue));
-                            yValuesPaths.push(parseFloat(yValue));
-                        });
-                    }
-                }
-            }
-        });
+        //                 splitC[1].split(",").forEach((coordinates) => {
+        //                     const splitSpaces = coordinates.split(" ");
+        //                     const xValue = splitSpaces[splitSpaces.length - 2];
+        //                     const yValue = splitSpaces[splitSpaces.length - 1];
+        //                     xValuesPaths.push(parseFloat(xValue));
+        //                     yValuesPaths.push(parseFloat(yValue));
+        //                 });
+        //             }
+        //         }
+        //     }
+        // });
         const xValuesNodes = nodes.map((node) => node.x);
         const yValuesNodes = nodes.map((node) => node.y);
 
-        const xValues = xValuesPaths.concat(xValuesNodes);
-        const yValues = yValuesPaths.concat(yValuesNodes);
+        // const xValues = xValuesPaths.concat(xValuesNodes);
+        // const yValues = yValuesPaths.concat(yValuesNodes);
 
-        const minX = Math.min(...xValues);
-        const minY = Math.min(...yValues);
+        const minX = Math.min(...xValuesNodes);
+        const minY = Math.min(...yValuesNodes);
 
-        const maxX = Math.max(...xValues) + nodeWidth;
-        const maxY = Math.max(...yValues) + nodeHeight;
+        const maxX = Math.max(...xValuesNodes) + nodeWidth;
+        const maxY = Math.max(...yValuesNodes) + nodeHeight;
 
-        // console.log("minX", minX, "minY", minY, "width", maxX - minX, "height", maxY - minY);
         return {x: minX, y: minY, width: maxX - minX, height: maxY - minY};
     }
 
@@ -1498,30 +1496,38 @@ export var drawGraph = function (workbook) {
 
     function flexRectLimitBounds(
       BOUNDARY_MARGIN_X_L,
-      BOUNDARY_MARGIN_X_R
+      BOUNDARY_MARGIN_X_R,
+      BOUNDARY_MARGIN_Y
     ) {
       // limit flexContainer from exceeding bounding box
       // TODO: add 5 so flexibleContainerRect stays within BOUNDARY_MARGIN, remove hardcoded value later
       if (flexibleContainer) {
         // x left bound
-        if (flexibleContainer.x < 0) {
-          flexibleContainer.x = BOUNDARY_MARGIN_X_L;
+        if (flexibleContainer.x < BOUNDARY_MARGIN_X_L) {
+        //   flexibleContainer.x = BOUNDARY_MARGIN_X_L;
+          console.log("left boundary exceeds", BOUNDARY_MARGIN_X_L);
         }
         // x right bound
         if (
-          flexibleContainer.width >
-          width - flexibleContainer.x - BOUNDARY_MARGIN_X_R
+            (graphZoom * flexibleContainer.width +
+              graphZoom * flexibleContainer.x) > $container.width() * graphZoom - BOUNDARY_MARGIN_X_R
         ) {
-          flexibleContainer.width =
-            width - flexibleContainer.x - BOUNDARY_MARGIN_X_R;
+            // flexibleContainer.width = $container.width() - flexibleContainer.width - BOUNDARY_MARGIN_X_R;
+          console.log(
+            "right boundary exceeds",
+            BOUNDARY_MARGIN_X_R,
+            $container.width() -
+              (graphZoom * flexibleContainer.width +
+                graphZoom * flexibleContainer.x)
+          );
         }
         // y top bound
-        if (flexibleContainer.y < 0) {
-          flexibleContainer.y = 0 + 5;
+        if (flexibleContainer.y < BOUNDARY_MARGIN_Y) {
+          flexibleContainer.y = BOUNDARY_MARGIN_Y;
         }
         // y bottom bound
-        if (flexibleContainer.height > height - flexibleContainer.y - 5) {
-          flexibleContainer.height = height - flexibleContainer.y - 5;
+        if (flexibleContainer.height > height - flexibleContainer.y) {
+          flexibleContainer.height = height - flexibleContainer.y;
         }
       }
     }
@@ -1561,7 +1567,6 @@ export var drawGraph = function (workbook) {
                   graphZoom * flexibleContainer.x)
             ) {
                 BOUNDARY_MARGIN_X_R = Math.abs(xTranslation);
-                console.log("BOUNDARY_MARGIN_X_R", BOUNDARY_MARGIN_X_R, flexibleContainer.x + flexibleContainer.width)
             }
             if (
               Math.abs(yTranslation) >
@@ -1577,13 +1582,14 @@ export var drawGraph = function (workbook) {
 
         if (!adaptive) {
             flexibleContainer = calcFlexiBox();
-            flexRectLimitBounds(BOUNDARY_MARGIN_X_R, BOUNDARY_MARGIN_X_L);
+            flexRectLimitBounds(BOUNDARY_MARGIN_X_R, BOUNDARY_MARGIN_X_L, BOUNDARY_MARGIN_Y);
 
             flexibleContainerRect
                 .attr("x", flexibleContainer.x)
                 .attr("y", flexibleContainer.y)
                 .attr("width", flexibleContainer.width)
                 .attr("height", flexibleContainer.height);
+            // console.log(flexibleContainer.x, flexibleContainer.width)
         }
         
 

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1549,9 +1549,6 @@ export var drawGraph = function (workbook) {
                 console.log("left bound violated")
                 BOUNDARY_MARGIN_X_L = -xTranslation / graphZoom;
             }
-            // console.log($container.width() -
-            //       (graphZoom * flexibleContainer.width +
-            //         graphZoom * flexibleContainer.x))
             if (
               xTranslation >=
               $container.width() -
@@ -1621,12 +1618,11 @@ export var drawGraph = function (workbook) {
               .attr("height", flexibleContainer.height);
 
             boundingBoxRect
-                .attr("x", -xTranslation)
+                .attr("x", -xTranslation / graphZoom + BOUNDARY_MARGIN_X_L / 2)
                 .attr("width", width / graphZoom - BOUNDARY_MARGIN_X_R)
-                .attr("y", -yTranslation)
-                .attr("height", height / graphZoom - BOUNDARY_MARGIN_X_R);
+                .attr("y", -yTranslation / graphZoom + BOUNDARY_MARGIN_Y_T)
+                .attr("height", height / graphZoom - BOUNDARY_MARGIN_Y_B / 2);
         }
-        
 
         // this controls movement and position of nodes, clamps the nodes to boundary
         try {

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -181,7 +181,7 @@ export var drawGraph = function (workbook) {
           adaptive ||
           (!adaptive &&
             flexRectInBounds(graphZoom) &&
-            exportBoundsMoveDragY(graphZoom, d3.event.dx, d3.event.dy))
+            exportBoundsMoveDrag(graphZoom, d3.event.dx, d3.event.dy, false))
         ) {
           zoom.translateBy(
             zoomContainer,
@@ -278,11 +278,10 @@ export var drawGraph = function (workbook) {
     // let prevUpwardMoveViolated = false
     // issue where if drag graph and then move with arrows, exceed bounds, has something to do with yTranslation since for some reason the old value is kept
     // when use cursor, top and bottom bound are shifted up by same amount
-    function exportBoundsMoveDragY(graphZoom, dx, dy) {
+    function exportBoundsMoveDrag(graphZoom, dx, dy, dPadMove) {
         updateZoomContainerInfo();
         // console.log("dx", dx, dx * graphZoom, "flexibleContainer.x", flexibleContainer.x, "xTranslation", xTranslation, "viewport width", width)
         console.log("dy", dy, dy * graphZoom, "flexibleContainer.y", flexibleContainer.y, "yTranslation", yTranslation, "viewport height", height)
-
         // if (
         //   ((dx < 0 || xTranslation < 0) &&
         //     Math.abs(xTranslation) * graphZoom >=
@@ -319,6 +318,10 @@ export var drawGraph = function (workbook) {
               Math.abs(yTranslation) >= Math.floor(flexibleContainer.y) + dy ))
         ) {
           return false;
+        }
+
+        if (dPadMove && yTranslation < 0 && dy < 0 && Math.abs(yTranslation + dy) > flexibleContainer.y) {
+            return false
         }
         
         if (dy > 0 &&
@@ -540,7 +543,7 @@ export var drawGraph = function (workbook) {
         if (adaptive) {
             zoom.translateBy(zoomContainer, moveWidth, moveHeight);
         } else if (!adaptive) {
-            if (exportBoundsMoveDragY(graphZoom, moveWidth, moveHeight)) {
+            if (exportBoundsMoveDrag(graphZoom, moveWidth, moveHeight, true)) {
                 zoom.translateBy(zoomContainer, moveWidth, moveHeight);
                 updateZoomContainerInfo();
                 console.log("new yTranslation value", yTranslation)

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1452,7 +1452,7 @@ export var drawGraph = function (workbook) {
 
     // there is too much whitespace in flexiContainer
     function calcFlexiBox (BOUNDARY_MARGIN_X_L, BOUNDARY_MARGIN_X_R, BOUNDARY_MARGIN_Y_T, BOUNDARY_MARGIN_Y_B) {
-        console.log("calc flexi box run")
+        // console.log("calc flexi box run")
         const nodes = simulation.nodes()
         let nodeWidth = 0;
         if (nodes.length > 0) {
@@ -1504,9 +1504,10 @@ export var drawGraph = function (workbook) {
         // handle left x and y boundaries to not exceed BOUNDARY_MARGIN
         minX = minX < BOUNDARY_MARGIN_X_L ? BOUNDARY_MARGIN_X_L : minX;
         // TODO: probably need to factor in graphZoom
-        maxX = maxX > $container.width() ? $container.width() - BOUNDARY_MARGIN_X_R : maxX;
+        // maxX = maxX > $container.width() ? $container.width() - BOUNDARY_MARGIN_X_R : maxX;
         minY = minY < BOUNDARY_MARGIN_Y_T ? BOUNDARY_MARGIN_Y_T : minY;
-        maxY = maxY > $container.height() ? $container.height() - BOUNDARY_MARGIN_Y_B : maxY;
+        // maxY = maxY > $container.height() ? $container.height() - BOUNDARY_MARGIN_Y_B : maxY;
+
         // console.log("flexi box width and height", maxX - minX, "maxX", maxX, "minX", minX, "maxY - minY", maxY - minY, "maxY", maxY, "minY", minY)
         let width = 1234;
         if (maxX < 0 && minX < 0) {
@@ -1570,15 +1571,8 @@ export var drawGraph = function (workbook) {
                 // console.log("right bound violated");
                 // if (flexibleContainer.x * graphZoom < $container.width() / graphZoom / 2){
             BOUNDARY_MARGIN_X_R = width / graphZoom - BOUNDARY_MARGIN;
-                // } else {
-                //     BOUNDARY_MARGIN_X_R = Math.abs(xTranslation) / graphZoom;
-                // }
-            //   }
             BOUNDARY_MARGIN_Y_T = -yTranslation / graphZoom + BOUNDARY_MARGIN / 2;
-            // if (yTranslation >= height - (graphZoom * flexibleContainer.height + graphZoom * flexibleContainer.y)) {
-                // console.log("bottom bound violated")
             BOUNDARY_MARGIN_Y_B = height / graphZoom - BOUNDARY_MARGIN;
-            // }
         }
 
         var SELF_REFERRING_Y_OFFSET = 6;
@@ -1618,9 +1612,15 @@ export var drawGraph = function (workbook) {
                 width ${Math.round(flexibleContainerRect.attr("width"))}
                 x ${Math.round(flexibleContainerRect.attr("x"))}
                 maxX ${Math.round(flexibleContainer.maxX)}
+                boundX
+                ${Math.round(BOUNDARY_MARGIN_X_L)}
+                ${Math.round(BOUNDARY_MARGIN_X_R)}
                 height ${Math.round(flexibleContainerRect.attr("height"))}
                 y ${Math.round(flexibleContainerRect.attr("y"))}
                 maxY ${Math.round(flexibleContainer.maxY)}
+                boundY
+                ${Math.round(BOUNDARY_MARGIN_Y_T)}
+                ${Math.round(BOUNDARY_MARGIN_Y_B)}
                 `;
             $("#flexiBox-dimensions").text(flexDimensions);
 
@@ -1833,8 +1833,22 @@ export var drawGraph = function (workbook) {
     }
 
     function dragged (d) {
-        d.fx = d3.event.x;
-        d.fy = d3.event.y;
+        console.log(d, "d.fx", d3.event.x, "d.fy", d3.event.y)
+        if (!adaptive) {
+            if (d3.event.x + d.textWidth <= (-xTranslation / graphZoom + 5/2) + (width / graphZoom) - 5) {
+                d.fx = d3.event.x;
+            } else {
+                d.fx = (-xTranslation / graphZoom + 5/2) + (width / graphZoom) - 5 - d.textWidth;
+            }
+            if (d3.event.y + nodeHeight<= -yTranslation / graphZoom + 5 / 2 + height / graphZoom - 5) {
+                d.fy = d3.event.y;
+            } else {
+                d.fy = -yTranslation / graphZoom + 5 / 2 + height / graphZoom - 5 - nodeHeight;
+            }
+        } else {
+            d.fx = d3.event.x;
+            d.fy = d3.event.y;
+        }
     }
 
     grnState.simulation = simulation;

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -213,9 +213,17 @@ export var drawGraph = function (workbook) {
         .attr("width", width)
         .attr("height", height);
 
-    var boundingBoxContainer = zoomContainer.append("g")
-        .attr("stroke", "black")
-        .attr("stroke-width", 1); // appended another g here...
+    var boundingBoxContainer = zoomContainer.append("g"); // appended another g here...
+
+    // This rectangle catches all of the mousewheel and pan events, without letting
+    // them bubble up to the body.
+    boundingBoxContainer.append("rect")
+        .attr("width", width)
+        .attr("height", height)
+        .style("fill", "none")
+        .style("pointer-events", "all")
+        .attr("stroke", "none" )
+        .append("g");
 
     var flexibleContainerRect = boundingBoxContainer.append("rect")
         .attr("class", "boundingBox")
@@ -236,16 +244,6 @@ export var drawGraph = function (workbook) {
     }
 
     d3.select("svg").on("dblclick.zoom", null); // disables double click zooming
-
-    // This rectangle catches all of the mousewheel and pan events, without letting
-    // them bubble up to the body.
-    boundingBoxContainer.append("rect")
-        .attr("width", width)
-        .attr("height", height)
-        .style("fill", "none")
-        .style("pointer-events", "all")
-        .attr("stroke", "none" )
-        .append("g");
 
     // this controls the D-pad
     d3.selectAll(".scrollBtn").on("click", null); // Remove event handlers, if there were any.

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -226,6 +226,7 @@ export var drawGraph = function (workbook) {
         .attr("stroke", "black")
         .attr("stroke-width", 1)
         .attr("fill", "none")
+        .attr("id", "flexibleContainerRect");
 
     var zoom = d3.zoom()
         .scaleExtent([MIN_SCALE, ZOOM_ADAPTIVE_MAX_SCALE])
@@ -234,7 +235,6 @@ export var drawGraph = function (workbook) {
     svg.style("pointer-events", "all").call(zoomDrag)
         .style("font-family", "sans-serif");
 
-    // this is why drag happens inside the flexibleContainerRect
     function zoomed () {
         zoomContainer.attr("transform", d3.event.transform);
     }
@@ -432,9 +432,9 @@ export var drawGraph = function (workbook) {
         if (!fixed) {
             $("#restrict-graph-to-viewport span").removeClass("glyphicon-ok");
             $("input[name=viewport]").removeProp("checked");
-            // $container.addClass("cursorGrabbing");
             adaptive = true;
             d3.select("rect").attr("stroke", "none");
+            d3.select("#flexibleContainerRect").attr("stroke", "none")
             center();
         } else if (fixed) {
             $("#restrict-graph-to-viewport span").addClass("glyphicon-ok");
@@ -448,10 +448,12 @@ export var drawGraph = function (workbook) {
             }
             width = $container.width();
             height = $container.height();
+            // put a border with a gray stroke around the original container size
             d3.select("rect").attr("stroke", "#9A9A9A")
                 .attr("width", width)
                 .attr("height", height);
             $(".boundingBox").attr("width", width).attr("height", height);
+            d3.select("#flexibleContainerRect").attr("stroke", "black");
             center();
         }
         updateAppBasedOnZoomValue(); // Update zoom value within bounds
@@ -1477,6 +1479,7 @@ export var drawGraph = function (workbook) {
             flexibleContainer = calcFlexiBox();
             flexiCollision(flexibleContainer)
 
+            // TODO: do I need to make this transform and translate? This is firing too much
             flexibleContainerRect
                 .attr("x", flexibleContainer.x)
                 .attr("y", flexibleContainer.y)
@@ -1538,6 +1541,8 @@ export var drawGraph = function (workbook) {
                         });
                     }
                 }
+                // height += OFFSET_VALUE;
+                // boundingBoxContainer.attr("height", height);
                 return d.y = currentYPos;
             }).attr("transform", function (d) {
                 return "translate(" + d.x + "," + d.y + ")";

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1462,15 +1462,31 @@ export var drawGraph = function (workbook) {
         }
     }
 
-    function flexiRectInBounds() {
-        const xInBounds = flexibleContainer.width - flexibleContainer.x  <= width * graphZoom;
-        const yInBounds = flexibleContainer.height - flexibleContainer.y <= height * graphZoom;
-
-        return {x: xInBounds, y: yInBounds};
-    }
 
     // don't set flexibleContainer = calcFlexiBox or else the function does not stop running, only want to run on tick
     let flexibleContainer = null
+
+    function flexiRectInBounds() {
+        // x left bound
+        if (flexibleContainer.x < 0) {
+            flexibleContainer.x = 0
+        }
+
+        // x right bound
+        if (!(flexibleContainer.width - flexibleContainer.x  <= width * graphZoom)) {
+            flexibleContainer.width = width - flexibleContainer.x;
+        }
+
+        // y top bound
+        if (flexibleContainer.y < 0) {
+            flexibleContainer.y = 0;
+        }
+        
+        // y bottom bound
+        if (!(flexibleContainer.height - flexibleContainer.y <= height * graphZoom)) {
+            flexibleContainer.height = height - flexibleContainer.y;
+        }
+    }
 
     // Tick only runs while the graph physics are still running.
     // (I.e. when the graph is completely relaxed, tick stops running.)
@@ -1493,38 +1509,14 @@ export var drawGraph = function (workbook) {
 
         if (!adaptive) {
             flexibleContainer = calcFlexiBox();
-            flexiCollision(flexibleContainer)
+            flexiRectInBounds();
+            // flexiCollision(flexibleContainer)
 
-            console.log(flexiRectInBounds())
-            const flexiRectValidation = flexiRectInBounds()
-
-            // if outside x or y bounds, set flexiRect width or height to max size of bounding box
-            if (!flexiRectValidation.x) {
-                flexibleContainer.width = width - flexibleContainer.x;
-            }
-
-            if (!flexiRectValidation.y) {
-                flexibleContainer.height = height - flexibleContainer.y;
-            }
-            
-            // console.log("d3 events", d3.event)
-            // const flexiRectValidation = flexiRectInBounds(d3.event.dx, d3.event.dy)
-            // if (
-            //   d3.event.x &&d3.event.dy && flexiRectValidation[0] &&flexiRectValidation[1]
-            // ) 
-            // {
             flexibleContainerRect
                 .attr("x", flexibleContainer.x)
                 .attr("y", flexibleContainer.y)
                 .attr("width", flexibleContainer.width)
                 .attr("height", flexibleContainer.height);
-            // } else {
-            //   flexibleContainerRect
-            //     .attr("x", flexibleContainer.x)
-            //     .attr("y", flexibleContainer.y)
-            //     .attr("width", flexibleContainer.width)
-            //     .attr("height", flexibleContainer.height);
-            // }
         }
 
         // this controls movement and position of nodes

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -484,6 +484,8 @@ export var drawGraph = function (workbook) {
     d3.selectAll("input[name=viewport]").on("change", function () {
         var fixed = $(this).prop("checked");
         restrictGraphToViewport(fixed);
+        // refresh the graph so that nodes and paths are restricted
+        tick()
     });
 
     function center () {
@@ -1408,21 +1410,41 @@ export var drawGraph = function (workbook) {
     };
 
     //node has all the nodes
-    var nodes = simulation.nodes()
+    let nodes = simulation.nodes()
+    // let paths = link.selectAll("path").data()
 
     function calcFlexiBox (nodes) {
-        let nodeWidth = 0
-        if (nodes.length > 0) {
-            nodeWidth = nodes[0].textWidth + 8
+        // paths = link.selectAll("path").data();
+        // if (nodes && paths) {
+        if (nodes) {
+            let nodeWidth = 0;
+            if (nodes.length > 0) {
+                nodeWidth = nodes[0].textWidth + 8;
+            }
+
+            // const xValuesPaths = paths.map((path) => path.label.x);
+            // const yValuesPaths = paths.map((path) => path.label.y);
+
+            const xValuesNodes = nodes.map((node) => node.x);
+            const yValuesNodes = nodes.map((node) => node.y);
+
+            // const xValues = xValuesPaths.concat(xValuesNodes);
+            // const yValues = yValuesPaths.concat(yValuesNodes);
+            const xValues = xValuesNodes
+            const yValues = yValuesNodes
+
+            const minX = Math.min(...xValues);
+            const minY = Math.min(...yValues);
+
+            const maxX = Math.max(...xValues) + nodeWidth;
+            const maxY = Math.max(...yValues) + nodeHeight;
+            return {
+                x: minX,
+                y: minY,
+                width: maxX - minX,
+                height: maxY - minY,
+            };
         }
-        const xValues = nodes.map(node => node.x)
-        const yValues = nodes.map(node => node.y)
-        const minX = Math.min(...xValues)
-        const minY = Math.min(...yValues)
-    
-        const maxX = Math.max(...xValues) + nodeWidth
-        const maxY = Math.max(...yValues) + nodeHeight
-        return {x: minX, y: minY, width: maxX - minX, height: maxY - minY}
     }
 
     // don't set flexibleContainer = calcFlexiBox or else the function does not stop running, only want to run on tick
@@ -1447,18 +1469,17 @@ export var drawGraph = function (workbook) {
         var MAX_HEIGHT = 5000;
         var OFFSET_VALUE = 5;
 
-        if (!adaptive) {
-            flexibleContainer = calcFlexiBox(nodes);
-
-            flexibleContainerRect
-                .attr("x", flexibleContainer.x)
-                .attr("y", flexibleContainer.y)
-                .attr("width", flexibleContainer.width)
-                .attr("height", flexibleContainer.height)
-        }
-
         // this controls movement and position of nodes
         try {
+            if (!adaptive) {
+                flexibleContainer = calcFlexiBox(nodes);
+
+                flexibleContainerRect
+                    .attr("x", flexibleContainer.x)
+                    .attr("y", flexibleContainer.y)
+                    .attr("width", flexibleContainer.width)
+                    .attr("height", flexibleContainer.height);
+            }
             node.attr("x", function (d) {
                 var selfReferringEdge = getSelfReferringEdge(d);
 

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -204,16 +204,14 @@ export var drawGraph = function (workbook) {
         .attr("height", height)
         .attr("id", "exportContainer");
 
-    var viewportBoundingBox = svg
-        .append("g")
-        .append("rect")
-        .attr("class", "boundingBox")
-        .attr("width", width)
-        .attr("height", height)
-        .style("fill", "none")
-        // .attr("stroke", "black")
-        // .attr("stroke-width", 2)
-        .attr("id", "viewportBoundingBox");
+    // var viewportBoundingBox = svg
+    //     .append("g")
+    //     .append("rect")
+    //     .attr("class", "boundingBox")
+    //     .attr("width", width)
+    //     .attr("height", height)
+    //     .style("fill", "none")
+    //     .attr("id", "viewportBoundingBox");
 
     var zoomContainer = svg.append("g") // required for zoom to work
         .attr("class", "boundingBox")
@@ -1458,15 +1456,22 @@ export var drawGraph = function (workbook) {
 
     function flexiCollision(flexibleContainer) {
         if (flexibleContainer) {
-            console.log("flexiCollision");
-            console.log(flexibleContainer.x, flexibleContainer.y, zoomContainer.attr("transform"))
-            console.log(svg.attr("width"), svg.attr("height"))
+            // console.log("flexiCollision");
+            // console.log(flexibleContainer.x, flexibleContainer.y, zoomContainer.attr("transform"))
+            // console.log(svg.attr("width"), svg.attr("height"))
         }
+    }
+
+    function flexiRectInBounds() {
+        const xInBounds = flexibleContainer.width - flexibleContainer.x  <= width * graphZoom;
+        const yInBounds = flexibleContainer.height - flexibleContainer.y <= height * graphZoom;
+
+        return {x: xInBounds, y: yInBounds};
     }
 
     // don't set flexibleContainer = calcFlexiBox or else the function does not stop running, only want to run on tick
     let flexibleContainer = null
-    
+
     // Tick only runs while the graph physics are still running.
     // (I.e. when the graph is completely relaxed, tick stops running.)
     function tick () {
@@ -1490,12 +1495,36 @@ export var drawGraph = function (workbook) {
             flexibleContainer = calcFlexiBox();
             flexiCollision(flexibleContainer)
 
-            // TODO: do I need to make this transform and translate? This is firing too much
+            console.log(flexiRectInBounds())
+            const flexiRectValidation = flexiRectInBounds()
+
+            // if outside x or y bounds, set flexiRect width or height to max size of bounding box
+            if (!flexiRectValidation.x) {
+                flexibleContainer.width = width - flexibleContainer.x;
+            }
+
+            if (!flexiRectValidation.y) {
+                flexibleContainer.height = height - flexibleContainer.y;
+            }
+            
+            // console.log("d3 events", d3.event)
+            // const flexiRectValidation = flexiRectInBounds(d3.event.dx, d3.event.dy)
+            // if (
+            //   d3.event.x &&d3.event.dy && flexiRectValidation[0] &&flexiRectValidation[1]
+            // ) 
+            // {
             flexibleContainerRect
                 .attr("x", flexibleContainer.x)
                 .attr("y", flexibleContainer.y)
                 .attr("width", flexibleContainer.width)
                 .attr("height", flexibleContainer.height);
+            // } else {
+            //   flexibleContainerRect
+            //     .attr("x", flexibleContainer.x)
+            //     .attr("y", flexibleContainer.y)
+            //     .attr("width", flexibleContainer.width)
+            //     .attr("height", flexibleContainer.height);
+            // }
         }
 
         // this controls movement and position of nodes

--- a/web-client/views/upload.pug
+++ b/web-client/views/upload.pug
@@ -288,8 +288,7 @@ html
           ul(class='nav navbar-nav navbar-right graph-metadata-container')
             li(class='navbar-text text-right')
               small(id='graph-metadata')
-          
-    
+
     div(class='container')
       div(class='grnsight-container' data-iframe-width data-iframe-height)
         div(class='scale-and-scroll')

--- a/web-client/views/upload.pug
+++ b/web-client/views/upload.pug
@@ -285,8 +285,6 @@ html
               include components/demo.pug
             li
               a(href='#' id='fileName')
-            li
-              a(href='#' id='flexiBox-dimensions')
           ul(class='nav navbar-nav navbar-right graph-metadata-container')
             li(class='navbar-text text-right')
               small(id='graph-metadata')

--- a/web-client/views/upload.pug
+++ b/web-client/views/upload.pug
@@ -285,10 +285,13 @@ html
               include components/demo.pug
             li
               a(href='#' id='fileName')
+            li
+              a(href='#' id='flexiBox-dimensions')
           ul(class='nav navbar-nav navbar-right graph-metadata-container')
             li(class='navbar-text text-right')
               small(id='graph-metadata')
-
+          
+    
     div(class='container')
       div(class='grnsight-container' data-iframe-width data-iframe-height)
         div(class='scale-and-scroll')


### PR DESCRIPTION
When restrict graph to viewport all *nodes*, not edges, are restricted to viewport. Graph does not exceed viewport even when dragged, zoomed, or moved with Dpad. 