### PR TITLE
Fixing PR #1112 to Restrict D-pad

### DIFF
--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -483,8 +483,8 @@ export var drawGraph = function (workbook) {
         if (adaptive) {
             zoom.translateBy(zoomContainer, moveWidth, moveHeight);
         } else if (!adaptive) {
-            if ((graphZoom, moveWidth, moveHeight)) {
-                zoom.translateBy(zoomContainer, moveWidth, moveHeight);
+            if (viewportBoundsMoveDrag(graphZoom, moveWidth, moveHeight)) {
+              zoom.translateBy(zoomContainer, moveWidth, moveHeight);
             }
         }
     }

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -484,7 +484,7 @@ export var drawGraph = function (workbook) {
             zoom.translateBy(zoomContainer, moveWidth, moveHeight);
         } else if (!adaptive) {
             if (viewportBoundsMoveDrag(graphZoom, moveWidth, moveHeight)) {
-              zoom.translateBy(zoomContainer, moveWidth, moveHeight);
+                zoom.translateBy(zoomContainer, moveWidth, moveHeight);
             }
         }
     }


### PR DESCRIPTION
After going through PR checklist for PR #1112 , realized D-pad was not being restricted properly. I had to adjust one line of the code in `move` function because I did not call the viewportBoundsMoveDrag function and instead just had an if statement that said `if ((graphZoom, moveWidth, moveHeight))`. Updated code to `if (viewportBoundsMoveDrag(graphZoom, moveWidth, moveHeight))` and now D-pad is being restricted as expected. 
 