### PR TITLE
Restrict Graph to Viewport Hotfix: Navbar 

### DIFF
--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -456,20 +456,18 @@ export var drawGraph = function (workbook) {
             center();
         }
         updateAppBasedOnZoomValue(); // Update zoom value within bounds
+        // Refresh the graph so that nodes and paths are adjusted to fit in viewport
+        tick();
     };
 
     d3.select("#restrict-graph-to-viewport").on("click", function () {
         var fixed = $("input[name=viewport]").prop("checked");
         restrictGraphToViewport(fixed);
-        // Refresh graph so nodes and paths are adjusted to fit in viewport when restricted to viewport in navbar
-        tick();
     });
 
     d3.selectAll("input[name=viewport]").on("change", function () {
         var fixed = $(this).prop("checked");
         restrictGraphToViewport(fixed);
-        // Refresh the graph so that nodes and paths are adjusted to fit in viewport when restrictd to viewport in sidebar
-        tick();
     });
 
     function center () {

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -461,12 +461,14 @@ export var drawGraph = function (workbook) {
     d3.select("#restrict-graph-to-viewport").on("click", function () {
         var fixed = $("input[name=viewport]").prop("checked");
         restrictGraphToViewport(fixed);
+        // Refresh graph so nodes and paths are adjusted to fit in viewport when restricted to viewport in navbar
+        tick();
     });
 
     d3.selectAll("input[name=viewport]").on("change", function () {
         var fixed = $(this).prop("checked");
         restrictGraphToViewport(fixed);
-        // Refresh the graph so that nodes and paths are adjusted to fit in viewport when restrictd to viewport
+        // Refresh the graph so that nodes and paths are adjusted to fit in viewport when restrictd to viewport in sidebar
         tick();
     });
 


### PR DESCRIPTION
Hotfix for 7.1 release #1077. Graph is updated to fit within bounds when zoomed into the graph when Restrict Graph to Viewport is selected in navbar. Do this by calling tick() when the restrict graph to viewport option is clicked in navbar, just like how tick is called when click Restrict Graph to Viewport option in sidebar.