### PR TITLE
#1106 Allowing query for any gene in gene table even if it's not in network table

### DIFF
--- a/server/dals/network-dal.js
+++ b/server/dals/network-dal.js
@@ -21,12 +21,10 @@ const buildNetworkSourceQuery = function () {
     return "SELECT * FROM gene_regulatory_network.source ORDER BY time_stamp DESC;";
 };
 
-const buildNetworkGeneFromSourceQuery = function (gene, source, timestamp) {
+const buildNetworkGeneFromSourceQuery = function (gene) {
     return `SELECT DISTINCT gene_id, display_gene_id FROM 
-    gene_regulatory_network.network, gene_regulatory_network.gene WHERE
-    network.time_stamp='${timestamp}' AND network.source='${source}' AND
-    (gene.gene_id ='${gene}' OR gene.display_gene_id ='${gene}') AND
-    (gene.gene_id = network.regulator_gene_id OR gene.gene_id = network.target_gene_id);`;
+    gene_regulatory_network.gene WHERE (gene.gene_id ='${gene}'
+    OR gene.display_gene_id ='${gene}')`;
 };
 
 const buildNetworkGenesQuery = function (geneString) {
@@ -49,7 +47,7 @@ const buildGenerateNetworkQuery = function (genes, source, timestamp) {
 const buildQueryByType = function (queryType, query) {
     const networkQueries = {
         "NetworkSource": () => buildNetworkSourceQuery(),
-        "NetworkGeneFromSource": () => buildNetworkGeneFromSourceQuery(query.gene, query.source, query.timestamp),
+        "NetworkGeneFromSource": () => buildNetworkGeneFromSourceQuery(query.gene),
         "GenerateNetwork": () => buildGenerateNetworkQuery(query.genes, query.source, query.timestamp)
     };
     if (Object.keys(networkQueries).includes(query.type)) {


### PR DESCRIPTION
After merging both gene tables from PPI and GRN, we still can't query ERT1 because ERT1 is not in network table. In order to fix that, change the database query to only query in the gene table. 