### PR TITLE
#1098 Fixing file selector appears twice after importing wrong file

### DIFF
--- a/web-client/public/js/setup-load-and-import-handlers.js
+++ b/web-client/public/js/setup-load-and-import-handlers.js
@@ -171,8 +171,7 @@ export const setupLoadAndImportHandlers = (grnState) => {
      * for helping to resolve this.
      */
 
-    $("body").on("change", "#upload-network", uploadHandler(loadGrn));
-    $("body").on("change", "#upload-nav", uploadHandler(loadGrn));
+    $("body").on("change", ".upload", uploadHandler(loadGrn));
 
     const loadDemo = (url, value) => {
         $("#demoSourceDropdown option[value='" + value.substring(1) + "']").prop(

--- a/web-client/public/js/setup-load-and-import-handlers.js
+++ b/web-client/public/js/setup-load-and-import-handlers.js
@@ -171,8 +171,9 @@ export const setupLoadAndImportHandlers = (grnState) => {
      * for helping to resolve this.
      */
 
-    // $(".upload").change(uploadHandler(loadGrn));
-    $("body").on("change", ".upload", uploadHandler(loadGrn));
+    $("body").on("change", "#upload-network", uploadHandler(loadGrn));
+    $("body").on("change", "#upload-nav", uploadHandler(loadGrn));
+
     const loadDemo = (url, value) => {
         $("#demoSourceDropdown option[value='" + value.substring(1) + "']").prop(
             "selected",

--- a/web-client/views/upload.pug
+++ b/web-client/views/upload.pug
@@ -513,7 +513,7 @@ html
             p(id='error')
           div(class='modal-footer')
             input(type='button' class='btn btn-default' data-dismiss='modal' value='Close')
-            input(type='button' id='launchFileOpen' class='btn btn-primary' data-dismiss='modal' value='Select New File' onclick="$('.upload').click()")
+            input(type='button' id='launchFileOpen' class='btn btn-primary' data-dismiss='modal' value='Select New File' onclick="$('#upload-network').click()")
 
     div(id='warningsModal' class='modal fade' tab-index='-1' role='dialog' aria-labelledby='mySmallModalLabel' aria-hidden='true' data-backdrop="static")
       div(class='modal-dialog')


### PR DESCRIPTION
The root cause was that when the user clicks on "Select New File," it triggers ".upload".click(). But the class upload is bound to two Open File buttons: one in the sidebar and one at the top bar, which triggers the file selector twice.