### PR TITLE
#1068 Allow node coloring for PPI by matching the gene name (MERGE #1080 first)

### DIFF
--- a/server/dals/expression-dal.js
+++ b/server/dals/expression-dal.js
@@ -20,7 +20,7 @@ var sequelize = new Sequelize(
 const buildExpressionGenesQuery = function (geneString) {
     let genes = "";
     let geneList = geneString.split(",");
-    geneList.forEach(x => genes += ( `(gene_expression.gene.display_gene_id =\'${x}\') OR `));
+    geneList.forEach(x => genes += ( `(LOWER(gene_expression.gene.display_gene_id) = LOWER(\'${x}\')) OR `));
     return genes.substring(0, genes.length - 4);
 };
 
@@ -62,7 +62,7 @@ const buildExpressionQuery = function (query) {
 const listExpressionGeneData = function (gene, totalOutput) {
     let listOfData = [];
     totalOutput.forEach(function (x) {
-        if (x.display_gene_id === gene) {
+        if (x.display_gene_id.toLowerCase() === gene.toLowerCase()) {
             listOfData.push(Number(x.expression));
         }
     });

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -11,7 +11,8 @@ import {
     ZOOM_DISPLAY_MAXIMUM_VALUE,
     ZOOM_DISPLAY_MIDDLE,
     ZOOM_ADAPTIVE_MAX_SCALE,
-    NETWORK_GRN_MODE
+    NETWORK_GRN_MODE,
+    NETWORK_PPI_MODE
 } from "./constants";
 
 /* globals d3 */
@@ -1087,11 +1088,15 @@ export var drawGraph = function (workbook) {
                 .selectAll(".coloring")
                 .data(function () {
                     if (grnState.workbook.expression[dataset]) {
+                        var geneName = p.name;
+                        if (grnState.workbook.meta.data.workbookType === NETWORK_PPI_MODE && geneName.endsWith("p")) {
+                            geneName = geneName.slice(0, -1);
+                        }
                         if (
-                            grnState.workbook.expression[dataset].data[p.name]
+                            grnState.workbook.expression[dataset].data[geneName]
                         ) {
                             const result = getExpressionData(
-                                p.name,
+                                geneName,
                                 dataset,
                                 average
                             );

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1,6 +1,11 @@
 import Grid from "d3-v4-grid";
 import { grnState } from "./grnstate";
-import { modifyChargeParameter, modifyLinkDistanceParameter, valueValidator } from "./update-app";
+import {
+    modifyChargeParameter,
+    modifyLinkDistanceParameter,
+    valueValidator,
+    adjustGeneNameForExpression,
+} from "./update-app";
 import {
     ENDS_IN_EXPRESSION_REGEXP,
     VIEWPORT_FIT,
@@ -12,7 +17,6 @@ import {
     ZOOM_DISPLAY_MIDDLE,
     ZOOM_ADAPTIVE_MAX_SCALE,
     NETWORK_GRN_MODE,
-    NETWORK_PPI_MODE
 } from "./constants";
 
 /* globals d3 */
@@ -1088,10 +1092,7 @@ export var drawGraph = function (workbook) {
                 .selectAll(".coloring")
                 .data(function () {
                     if (grnState.workbook.expression[dataset]) {
-                        var geneName = p.name;
-                        if (grnState.workbook.meta.data.workbookType === NETWORK_PPI_MODE && geneName.endsWith("p")) {
-                            geneName = geneName.slice(0, -1);
-                        }
+                        const geneName = adjustGeneNameForExpression(p);
                         if (
                             grnState.workbook.expression[dataset].data[geneName]
                         ) {

--- a/web-client/public/js/update-app.js
+++ b/web-client/public/js/update-app.js
@@ -393,7 +393,12 @@ const loadExpressionDatabase = function (isTopDataset) {
         queryExpressionDatabase({
             type:"ExpressionData",
             dataset,
-            genes : grnState.workbook.genes.map(gene => {return gene.name;}).join(","),
+            genes : grnState.workbook.genes.map(gene => {
+                if (grnState.workbook.meta.data.workbookType === NETWORK_PPI_MODE) {
+                    return gene.name.endsWith("p") ? gene.name.slice(0, -1) : gene.name;
+                }
+                return gene.name;
+            }).join(","),
             timepoints: timepointsResponse[dataset]
         }).then(function (response) {
             if (isTopDataset) {

--- a/web-client/public/js/update-app.js
+++ b/web-client/public/js/update-app.js
@@ -383,11 +383,12 @@ const enableNodeColoringUI = function () {
     $(LOG_FOLD_CHANGE_MAX_VALUE_HEADER).removeClass("hidden");
 };
 
-const adjustGeneNameForExpression = function(gene) {
+const adjustGeneNameForExpression = function (gene) {
+    const geneName = gene.name;
     return grnState.workbook.meta.data.workbookType === NETWORK_PPI_MODE &&
-        gene.name.endsWith("p")
-        ? gene.name.slice(0, -1)
-        : gene.name;
+        geneName.endsWith("p")
+        ? geneName.slice(0, -1)
+        : geneName;
 };
 
 const loadExpressionDatabase = function (isTopDataset) {
@@ -400,9 +401,9 @@ const loadExpressionDatabase = function (isTopDataset) {
         queryExpressionDatabase({
             type:"ExpressionData",
             dataset,
-            genes : grnState.workbook.genes.map(gene => {
-                return adjustGeneNameForExpression(gene);
-            }).join(","),
+            genes: grnState.workbook.genes
+                    .map(adjustGeneNameForExpression)
+                    .join(","),
             timepoints: timepointsResponse[dataset]
         }).then(function (response) {
             if (isTopDataset) {

--- a/web-client/public/js/update-app.js
+++ b/web-client/public/js/update-app.js
@@ -383,6 +383,13 @@ const enableNodeColoringUI = function () {
     $(LOG_FOLD_CHANGE_MAX_VALUE_HEADER).removeClass("hidden");
 };
 
+const adjustGeneNameForExpression = function(gene) {
+    return grnState.workbook.meta.data.workbookType === NETWORK_PPI_MODE &&
+        gene.name.endsWith("p")
+        ? gene.name.slice(0, -1)
+        : gene.name;
+};
+
 const loadExpressionDatabase = function (isTopDataset) {
     const dataset = isTopDataset ? grnState.nodeColoring.topDataset : grnState.nodeColoring.bottomDataset;
     startLoadingIcon();
@@ -394,10 +401,7 @@ const loadExpressionDatabase = function (isTopDataset) {
             type:"ExpressionData",
             dataset,
             genes : grnState.workbook.genes.map(gene => {
-                if (grnState.workbook.meta.data.workbookType === NETWORK_PPI_MODE) {
-                    return gene.name.endsWith("p") ? gene.name.slice(0, -1) : gene.name;
-                }
-                return gene.name;
+                return adjustGeneNameForExpression(gene);
             }).join(","),
             timepoints: timepointsResponse[dataset]
         }).then(function (response) {
@@ -1004,4 +1008,4 @@ export const updateApp = grnState => {
 };
 
 
-export { stopLoadingIcon, startLoadingIcon};
+export { stopLoadingIcon, startLoadingIcon, adjustGeneNameForExpression};


### PR DESCRIPTION
The cause was that the gene name wasn't matching when querying the expression database. For protein, the gene name has an additional "p" at the end.

I can make the node coloring appear for PPI if the user loads it from the database. However, the demos still have issues with displaying the node coloring, but I think it's the same root cause documented in https://github.com/dondi/GRNsight/issues/1080.