### PR TITLE
#1053 fixing p.length error

### DIFF
--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1101,9 +1101,7 @@ export var drawGraph = function (workbook) {
                                 average
                             );
                             timePoints = result.timePoints;
-                            return result.data && result.data.length > 0
-                                ? result.data
-                                : [];
+                            return result.data || [];
                         }
                     }
                     return [];

--- a/web-client/public/js/graph.js
+++ b/web-client/public/js/graph.js
@@ -1101,11 +1101,12 @@ export var drawGraph = function (workbook) {
                                 average
                             );
                             timePoints = result.timePoints;
-                            return result.data;
-                        } else {
-                            return 0;
+                            return result.data && result.data.length > 0
+                                ? result.data
+                                : [];
                         }
                     }
+                    return [];
                 })
                 .attr("class", "coloring")
                 .enter().append("rect")


### PR DESCRIPTION
The error is caused by d3 graph generated an empty <g> element. 
![Screenshot 2024-11-04 at 9 13 58 PM](https://github.com/user-attachments/assets/c8d0196d-54d4-4543-971e-eb22fddda0d0)



From chatGPT, 
>In D3, if the dataset passed to .data() is either null, undefined, or an empty array, D3 will create an element for each item in the array. If there is no data (e.g., the result of result.data is an empty array or 0), D3 will append an empty <g> element even if it has no meaningful data to display.

To prevent d3 create empty g element, we return an empty list instead

