### PR TITLE
Addition fix to previous fix for #1093

### DIFF
--- a/web-client/public/js/setup-handlers.js
+++ b/web-client/public/js/setup-handlers.js
@@ -94,13 +94,11 @@ export const setupHandlers = grnState => {
         window.document.body.appendChild(emptySvg);
         var emptySvgDeclarationComputed = getComputedStyle(emptySvg);
 
-        const traverse = svg => {
-            var tree = [];
-            tree.push(svg);
-            // implement DFS
-            const visit = (node) => {
-                if (node && node.hasChildNodes()) {
-                    var child = node.firstChild;
+        const traverse = (node) => {
+            const tree = [];
+            const visit = (currentNode) => {
+                if (currentNode && currentNode.hasChildNodes()) {
+                    let child = currentNode.firstChild;
                     while (child) {
                         if (child.nodeType === 1 && child.nodeName !== "SCRIPT") {
                             tree.push(child);
@@ -110,38 +108,38 @@ export const setupHandlers = grnState => {
                     }
                 }
             };
-            visit(svg);
+            visit(node);
             return tree;
         };
 
         const explicitlySetStyle = element => {
             const cSSStyleDeclarationComputed = window.getComputedStyle(element);
-            let i;
-            let len;
-            let key;
-            let value;
             let computedStyleStr = "";
 
-            for (i = 0, len = cSSStyleDeclarationComputed.length; i < len; i++) {
-                key = cSSStyleDeclarationComputed[i];
-                value = cSSStyleDeclarationComputed.getPropertyValue(key);
+            for (let i = 0; i < cSSStyleDeclarationComputed.length; i++) {
+                const key = cSSStyleDeclarationComputed[i];
+                const value = cSSStyleDeclarationComputed.getPropertyValue(key);
                 if (value !== emptySvgDeclarationComputed.getPropertyValue(key)) {
                     // Don't set computed style of width and height. Makes SVG elmements disappear.
                     if ((key !== "height") && (key !== "width")) {
-                        computedStyleStr += key + ":" + value + ";";
+                        computedStyleStr += `${key}:${value};`;
                     }
 
                 }
             }
-            element.setAttribute("style", computedStyleStr);
+
+            if (element.classList.contains("weight")) {
+                computedStyleStr += "visibility: hidden;";
+            }
+
+            if (computedStyleStr) {
+                element.setAttribute("style", computedStyleStr);
+            }
         };
 
         // hardcode computed css styles inside svg
         var allElements = traverse(svg);
-        var i = allElements.length;
-        while (i--) {
-            explicitlySetStyle(allElements[i]);
-        }
+        allElements.forEach(explicitlySetStyle);
     };
 
     const sourceAttributeSetter = (svg) => {

--- a/web-client/public/js/setup-handlers.js
+++ b/web-client/public/js/setup-handlers.js
@@ -113,27 +113,28 @@ export const setupHandlers = grnState => {
         };
 
         const explicitlySetStyle = element => {
-            const cSSStyleDeclarationComputed = window.getComputedStyle(element);
-            let computedStyleStr = "";
+            const cssStyleDeclarationComputed = window.getComputedStyle(element);
+            const computedStyleObj = {};    
 
-            for (let i = 0; i < cSSStyleDeclarationComputed.length; i++) {
-                const key = cSSStyleDeclarationComputed[i];
+
+            for (let i = 0; i < cssStyleDeclarationComputed.length; i++) {
+                const key = cssStyleDeclarationComputed[i];
                 const value = cSSStyleDeclarationComputed.getPropertyValue(key);
                 if (value !== emptySvgDeclarationComputed.getPropertyValue(key)) {
                     // Don't set computed style of width and height. Makes SVG elmements disappear.
                     if ((key !== "height") && (key !== "width")) {
-                        computedStyleStr += `${key}:${value};`;
+                        computedStyleObj[key] = value;
                     }
 
                 }
             }
 
             if (element.classList.contains("weight")) {
-                computedStyleStr += "visibility: hidden;";
+                computedStyleObj["visibility"] = "hidden";
             }
 
-            if (computedStyleStr) {
-                element.setAttribute("style", computedStyleStr);
+            if (computedStyleObj) {
+                Object.assign(element.style, computedStyleObj)
             }
         };
 

--- a/web-client/public/js/setup-handlers.js
+++ b/web-client/public/js/setup-handlers.js
@@ -119,7 +119,7 @@ export const setupHandlers = grnState => {
 
             for (let i = 0; i < cssStyleDeclarationComputed.length; i++) {
                 const key = cssStyleDeclarationComputed[i];
-                const value = cSSStyleDeclarationComputed.getPropertyValue(key);
+                const value = cssStyleDeclarationComputed.getPropertyValue(key);
                 if (value !== emptySvgDeclarationComputed.getPropertyValue(key)) {
                     // Don't set computed style of width and height. Makes SVG elmements disappear.
                     if ((key !== "height") && (key !== "width")) {


### PR DESCRIPTION
When exporting the svg, using cloneNode making the image to be all black. This is because style didn't pass correctly. This makes sure the style is correct. 