### PR TITLE
#1142: Warning String Displays Correctly

### DIFF
--- a/web-client/public/js/warnings.js
+++ b/web-client/public/js/warnings.js
@@ -43,6 +43,8 @@ export var displayWarnings = function (warnings) {
         index++;
     }
 
+    $("#warningsList").html(warningsString);
+
     var screenHeight = $(window).height();
     var MIN_SCREEN_HEIGHT = 600;
     var BORDER = 425;


### PR DESCRIPTION
Added line that correctly displays warning string with DB5 file which solves Issue #1142 . I must have deleted this line accidentally when working with warning strings in a previous PR.