### PR TITLE
#1147 include npm lint 

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,6 +28,7 @@ jobs:
         cache: 'npm'
         
     - run: npm ci
+    - run: npm run lint 
     - run: npm run build --if-present
     - run: npm test
 

--- a/web-client/public/js/setup-handlers.js
+++ b/web-client/public/js/setup-handlers.js
@@ -114,7 +114,7 @@ export const setupHandlers = grnState => {
 
         const explicitlySetStyle = element => {
             const cssStyleDeclarationComputed = window.getComputedStyle(element);
-            const computedStyleObj = {};    
+            const computedStyleObj = {};
 
 
             for (let i = 0; i < cssStyleDeclarationComputed.length; i++) {
@@ -134,7 +134,7 @@ export const setupHandlers = grnState => {
             }
 
             if (computedStyleObj) {
-                Object.assign(element.style, computedStyleObj)
+                Object.assign(element.style, computedStyleObj);
             }
         };
 


### PR DESCRIPTION
Regarding #1147 -- Includes `npm lint` in the GitHub Action CI script.  Running the lint checker will help catch formatting issues on an ongoing basis.