### PR TITLE
Resetting Demo Dropdown #1150

### DIFF
--- a/web-client/public/js/update-app.js
+++ b/web-client/public/js/update-app.js
@@ -549,6 +549,11 @@ const updateModeViews = () =>{
     }
 };
 
+const resetDemoDropdown = () =>{
+    $("#demoSourceDropdown option").removeAttr("selected");
+    $("#demoSourceDropdown").val("none");
+};
+
 const checkWorkbookModeSettings = () => {
     const hasExpression = hasExpressionData(grnState.workbook.expression);
 
@@ -589,6 +594,11 @@ $(NETWORK_MODE_PROTEIN_PHYS).on("click", () => {
 });
 $(NETWORK_MODE_GRN).on("click", () => {
     grnState.mode = NETWORK_GRN_MODE;
+    checkWorkbookModeSettings();
+    refreshApp();
+});
+$("body").on("click", "#submit-network", function () {
+    resetDemoDropdown();
     checkWorkbookModeSettings();
     refreshApp();
 });


### PR DESCRIPTION
We added a function in update-app.js to reset the Demo Dropdown, and call it when the Generate Network button is clicked, which seems to have fixed the bug of the original demo not being able to be reclicked after generating a network. There is a possibility that this code can be condensed/placed in a different place, but we were unsure about trying that out.