### PR TITLE
Improving upon #1183 hotfix

### DIFF
--- a/server/dals/dbConstants.js
+++ b/server/dals/dbConstants.js
@@ -1,17 +1,17 @@
-const GRN_DATABASE_NAMESPACE = "gene_regulatory_network_with_timestamp";
-const GRN_DATABASE_NAMESPACE_OLD = "gene_regulatory_network";
-const PPI_DATABASE_NAMESPACE = "protein_protein_interactions_with_timestamp";
-const PPI_DATABASE_NAMESPACE_OLD = "protein_protein_interactions";
+const GRN_DATABASE_NAMESPACE_WITH_TIMESTAMP = "gene_regulatory_network_with_timestamp";
+const GRN_DATABASE_NAMESPACE = "gene_regulatory_network";
+const PPI_DATABASE_NAMESPACE_WITH_TIMESTAMP = "protein_protein_interactions_with_timestamp";
+const PPI_DATABASE_NAMESPACE = "protein_protein_interactions";
 const DATABASE_TIMESTAMP_CUTOFF = new Date("2025-01-01");
 
 const timestampNamespace = function (timestamp, isGrn) {
     return new Date(timestamp) > new Date("2025-01-01")
         ? isGrn
-            ? GRN_DATABASE_NAMESPACE
-            : PPI_DATABASE_NAMESPACE
+            ? GRN_DATABASE_NAMESPACE_WITH_TIMESTAMP
+            : PPI_DATABASE_NAMESPACE_WITH_TIMESTAMP
         : isGrn
-        ? GRN_DATABASE_NAMESPACE_OLD
-        : PPI_DATABASE_NAMESPACE_OLD;
+        ? GRN_DATABASE_NAMESPACE
+        : PPI_DATABASE_NAMESPACE;
 };
 
 const isTimestampOld = function (timestamp) {
@@ -21,4 +21,8 @@ const isTimestampOld = function (timestamp) {
 module.exports = {
     timestampNamespace,
     isTimestampOld,
+    GRN_DATABASE_NAMESPACE_WITH_TIMESTAMP: GRN_DATABASE_NAMESPACE_WITH_TIMESTAMP,
+    GRN_DATABASE_NAMESPACE: GRN_DATABASE_NAMESPACE,
+    PPI_DATABASE_NAMESPACE_WITH_TIMESTAMP: PPI_DATABASE_NAMESPACE_WITH_TIMESTAMP,
+    PPI_DATABASE_NAMESPACE: PPI_DATABASE_NAMESPACE,
 };

--- a/server/dals/network-dal.js
+++ b/server/dals/network-dal.js
@@ -14,9 +14,9 @@ var sequelize = new Sequelize(config.databaseName, process.env.DB_USERNAME, proc
 });
 
 const buildNetworkSourceQuery = function () {
-    return `SELECT * FROM gene_regulatory_network.source
+    return `SELECT * FROM ${constants.GRN_DATABASE_NAMESPACE}.source
             UNION ALL
-            SELECT * FROM gene_regulatory_network_new.source
+            SELECT * FROM ${constants.GRN_DATABASE_NAMESPACE_WITH_TIMESTAMP}.source
             ORDER BY time_stamp DESC;`;
 };
 

--- a/server/dals/protein-dal.js
+++ b/server/dals/protein-dal.js
@@ -14,9 +14,9 @@ var sequelize = new Sequelize(config.databaseName, process.env.DB_USERNAME, proc
 });
 
 const buildNetworkSourceQuery = function () {
-    return `SELECT * FROM protein_protein_interactions.source
+    return `SELECT * FROM ${constants.PPI_DATABASE_NAMESPACE}.source
             UNION ALL
-            SELECT * FROM protein_protein_interactions_new.source
+            SELECT * FROM ${constants.PPI_DATABASE_NAMESPACE_WITH_TIMESTAMP}.source
             ORDER BY time_stamp DESC;`;
 };
 


### PR DESCRIPTION
Was using hardcoded namespace instead of constants, so exported namespaces from dbConstants. Changed variable names for constants to include `with_timestamp` instead of `_old`.