### PR TITLE
Updating coverage link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ GRNsight
 ========
 [![DOI](https://zenodo.org/badge/16195791.svg)](https://zenodo.org/badge/latestdoi/16195791)
 [![Node.js CI](https://github.com/dondi/GRNsight/actions/workflows/node.js.yml/badge.svg)](https://github.com/dondi/GRNsight/actions/workflows/node.js.yml)
-[![Coverage Status](https://coveralls.io/repos/github/dondi/GRNsight/badge.svg?branch=master)](https://coveralls.io/github/dondi/GRNsight?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/dondi/GRNsight/badge.svg?branch=beta)](https://coveralls.io/github/dondi/GRNsight?branch=beta)
 
 http://dondi.github.io/GRNsight/
 


### PR DESCRIPTION
Regarding #1148  -- This PR updates the Coveralls coverage badge in the README to point to the beta branch instead of master, since master no longer exists. It also ensures coverage reports are properly uploaded from beta. Once main begins pushing coverage, we can update the badge again. 