### PR TITLE
Opt Groups Cosmetic Change - for Issue #1211

### DIFF
--- a/web-client/public/stylesheets/grnsight.styl
+++ b/web-client/public/stylesheets/grnsight.styl
@@ -639,3 +639,10 @@ option {
 
 upload-network
   text-align: left
+
+.dataset-group-label
+  color black
+  padding-left 10px
+  font-weight bold
+  margin-top 5px
+  margin-bottom 5px


### PR DESCRIPTION
I updated the opt group labels so that the left side has more padding and the text is now black instead of gray.