### PR TITLE
Disabled Grid Layout button/menu item when no graph is loaded for issue #1214

### DIFF
--- a/web-client/public/js/update-app.js
+++ b/web-client/public/js/update-app.js
@@ -1075,6 +1075,11 @@ export const updateApp = grnState => {
         $(ZOOM_INPUT).val(ZOOM_DISPLAY_MIDDLE);
         $(ZOOM_SLIDER).val(ZOOM_ADAPTIVE_MAX_SCALE);
     }
+
+    if (grnState.workbook != null) {
+        $("#gridLayout").removeClass("disabled");
+        $("#gridLayoutButton").removeClass("disabled");
+    }
     refreshApp();
 };
 

--- a/web-client/public/stylesheets/grnsight.styl
+++ b/web-client/public/stylesheets/grnsight.styl
@@ -639,3 +639,8 @@ option {
 
 upload-network
   text-align: left
+
+.layout.disabled
+  pointer-events none
+  opacity 0.5
+  cursor not-allowed

--- a/web-client/views/upload.pug
+++ b/web-client/views/upload.pug
@@ -74,7 +74,7 @@ html
                 li
                   a(href='#' id='forceGraph' class='layout')
                     | &nbsp; &nbsp; &nbsp;Force Graph
-                  a(href='#' id='gridLayout' class='layout')
+                  a(href='#' id='gridLayout' class='layout disabled')
                     | &nbsp; &nbsp; &nbsp;Grid Layout
                 li(class='divider')
                 li
@@ -367,7 +367,7 @@ html
                   form(class='buttonPairContainer')
                     //- Value is set to empty to ensure that the MVC cycle takes care of the button’s label.
                     input(id='forceGraphButton' type='button' class='btn btn-default' value='Force Graph')
-                    input(id='gridLayoutButton' type='button' class='btn btn-default' value='Grid Layout')
+                    input(id='gridLayoutButton' type='button' class='btn btn-default disabled' value='Grid Layout')
                   form(class='forceParameterContainer')
                     div(class='labelWithValueContainer')
                       label(for='linkDistInput', class='info', data-toggle='tooltip', title='Increases/decreases the length of the edges that connect the nodes.') Link Distance (1-1000):


### PR DESCRIPTION
When no network graph is loaded, the Grid Layout button and menu item are now both disabled until a graph is loaded. CSS styling has been applied to show that those items are disabled to begin with as well.