### PR TITLE
Fixed issue with Menu bar overly expanding - for issue #1172

### DIFF
--- a/web-client/public/stylesheets/grnsight.styl
+++ b/web-client/public/stylesheets/grnsight.styl
@@ -100,6 +100,7 @@ form label, form span
   top: 1px
   margin-right: auto
   margin-bottom: 10px
+  width: 100%
 
 .dropdown-menu > li > a.upload
   padding-top: 7px
@@ -639,3 +640,8 @@ option {
 
 upload-network
   text-align: left
+
+body {
+  min-width: 1355px;
+  overflow-x: auto;
+}


### PR DESCRIPTION
Added styling through the grnsight.styl file to add horizontal scrolling to the whole web app window, keep the menu bar from oddly expanding when the demo file name was too long/window was too narrow, and line up the menu bar's minimum width with the main graph container beneath it.