### PR TITLE
Fixed print window functionality for PPIs - for Issue #1213

### DIFF
--- a/web-client/public/js/upload.js
+++ b/web-client/public/js/upload.js
@@ -47,7 +47,7 @@ export const upload = function () {
     styleLabelTooltips();
 
     $("#printGraph").click(function () {
-        if (!$(".startDisabled").hasClass("disabled")) {
+        if (uploadState.currentWorkbook) {
             window.print();
         }
     });


### PR DESCRIPTION
I updated the print window functionality so that it checked if there was a current workbook open, and this makes the print button work for all demos, including PPIs.