### PR TITLE
Fixed menu bar over-expanding issue and added side scrolling for issue #1172

### DIFF
--- a/web-client-classic/public/stylesheets/grnsight.styl
+++ b/web-client-classic/public/stylesheets/grnsight.styl
@@ -100,6 +100,7 @@ form label, form span
   top: 1px
   margin-right: auto
   margin-bottom: 10px
+  width: 100%
 
 .dropdown-menu > li > a.upload
   padding-top: 7px
@@ -651,3 +652,8 @@ upload-network
   font-weight bold
   margin-top 5px
   margin-bottom 5px
+
+body {
+  min-width: 1355px;
+  overflow-x: auto;
+}


### PR DESCRIPTION
Added styling through the grnsight.styl file to add horizontal scrolling to the whole web app window, keep the menu bar from oddly expanding when the demo file name was too long/window was too narrow, and line up the menu bar's minimum width with the main graph container beneath it.