### PR TITLE
Added wrap-around styling for demo name in export to excel window

### DIFF
--- a/web-client-classic/public/stylesheets/grnsight.styl
+++ b/web-client-classic/public/stylesheets/grnsight.styl
@@ -94,7 +94,7 @@ p
   margin-bottom: 15px
 
 form label, form span
-  margin: 5px
+  margin: 0 5px 5px 5px
 
 .navbar
   top: 1px
@@ -621,11 +621,11 @@ path.mousezone
 
 .export-radio-group li
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   margin-bottom: 8px;
 
 .export-radio
-  margin-top: 3px;
+  margin-top: 10px;
   margin-right: 8px;
   flex-shrink: 0;
 
@@ -636,6 +636,7 @@ path.mousezone
 
 .export-radio-label.disabled
   color: #AAA
+  
 
 # demoSourceDropdown > option {
   direction: ltr;


### PR DESCRIPTION
I don't think there's an official issue/ticket for this but I remember during our last meeting that Dr. Dhalquist mentioning wanting to fix how the demo name starts below the select button (in the export to excel pop-up) when the browser gets too narrow. I added wrap styling for when the browser is too narrow - see attached screenshot for what it looked like before vs now. If we want it to look differently I can change that as well but this is what I came up with!

<img width="477" height="482" alt="Screenshot 2025-10-31 at 4 50 25 PM" src="https://github.com/user-attachments/assets/317d6378-1c7c-4531-bbfb-89dc34e0552f" />
<img width="442" height="317" alt="Screenshot 2025-10-31 at 4 42 01 PM" src="https://github.com/user-attachments/assets/781f1bbc-b4f3-4922-a4f4-51b28dc7e357" />
