### PR TITLE
Fixes Issue #1216 - Resetting node coloring values after GRNs are loaded

### DIFF
--- a/web-client-classic/public/js/grnstate.js
+++ b/web-client-classic/public/js/grnstate.js
@@ -58,6 +58,15 @@ export const grnState = {
         // TODO: add colorOptimal so that the rest of the normalization code can get added
         this.resetNormalizationMax = max(workbook.positiveWeights.concat(workbook.negativeWeights));
         this.newWorkbook = true;
+
+        // Resetting nodeColoring values leftover from when you display a GRN
+        this.nodeColoring.showMenu = false;
+        this.nodeColoring.nodeColoringEnabled = undefined;
+        this.nodeColoring.topDataset = "";
+        this.nodeColoring.bottomDataset = "";
+        this.nodeColoring.lastDataset = "";
+        this.nodeColoring.nodeColoringOptions.workbookExpressions = [];
+        this.nodeColoring.nodeColoringOptions.databaseExpressions = [];
     },
 
     // Edge Display Parameters


### PR DESCRIPTION
In grnstate.js, we reset the various nodeColoring values that had leftover values set when a GRN was loaded. This allows PPIs to have the initial nodeColoring values and successfully enable node coloring. Fixes [Issue #1216](https://github.com/users/dondi/projects/2/views/1?sliceBy%5Bvalue%5D=MilkaZek&pane=issue&itemId=128783755&issue=dondi%7CGRNsight%7C1216)