### PR TITLE
Removed workbook expression data and concentration_sigmas for Demo 3 - fixes Issue 1276

### DIFF
--- a/server/controllers/demo-workbooks.js
+++ b/server/controllers/demo-workbooks.js
@@ -3035,8 +3035,7 @@ var demoWorkbook3 = function (path, res, app) {
             },
         },
         twoColumnSheets: {},
-        expression: {
-        },
+        expression: {},
     };
     return processDemo(path, res, app, workbook3);
 };


### PR DESCRIPTION
We removed the expression data and concentration_sigmas for Demo 3 in demo-workbooks.js. When we tried to get rid of the expression object completely, the browser crashed when we tried to load Demo 3, so we kept expression as an empty object. Fixes [Issue #1276](https://github.com/users/dondi/projects/2/views/1?sliceBy%5Bvalue%5D=MilkaZek&pane=issue&itemId=138978664&issue=dondi%7CGRNsight%7C1276)