### PR TITLE
Fixes Issue 1273 - Updated edge coloring enabling logic to be attached to presence of network edge weights

### DIFF
--- a/server/controllers/network-sheet-parser.js
+++ b/server/controllers/network-sheet-parser.js
@@ -330,7 +330,7 @@ var parseNetworkSheet = function (sheet, network) {
 exports.workbookType = function (workbookFile) {
     let workbookType;
     for (const sheet of workbookFile) {
-        if (sheet.name.toLowerCase() === "network") {
+        if (sheet.name.toLowerCase() === "network" || sheet.name.toLowerCase() === "network_optimized_weights") {
             const cellA1 = sheet.data[0][0];
 
             if (cellA1 === CELL_A1_GRN) {
@@ -347,6 +347,7 @@ exports.workbookType = function (workbookFile) {
 };
 
 exports.networks = function (workbookFile) {
+    console.log("Made ittt")
     const networks = {
         network: {},
         networkOptimizedWeights: {},
@@ -362,19 +363,23 @@ exports.networks = function (workbookFile) {
                 element,
                 initWorkbook({ sheetType: "unweighted" })
             );
+            console.log("network")
         } else if (element.name.toLowerCase() === "network_optimized_weights") {
             // We found a network sheet with optimized weights, which is the ideal data source.
             networks.networkOptimizedWeights = parseNetworkSheet(
                 element,
                 initWorkbook({ sheetType: "weighted" })
             );
+            console.log("network_optimized_weights")
         } else if (element.name.toLowerCase() === "network_weights") {
             // We found a network_weights sheet to preserve existing network type sheet data
             networks.networkWeights = parseNetworkSheet(
                 element,
                 initWorkbook({ sheetType: "weighted" })
             );
+            console.log("network_weights")
         }
+        console.log("I am here!")
     }
 
     if (

--- a/server/controllers/network-sheet-parser.js
+++ b/server/controllers/network-sheet-parser.js
@@ -363,23 +363,19 @@ exports.networks = function (workbookFile) {
                 element,
                 initWorkbook({ sheetType: "unweighted" })
             );
-            console.log("network")
         } else if (element.name.toLowerCase() === "network_optimized_weights") {
             // We found a network sheet with optimized weights, which is the ideal data source.
             networks.networkOptimizedWeights = parseNetworkSheet(
                 element,
                 initWorkbook({ sheetType: "weighted" })
             );
-            console.log("network_optimized_weights")
         } else if (element.name.toLowerCase() === "network_weights") {
             // We found a network_weights sheet to preserve existing network type sheet data
             networks.networkWeights = parseNetworkSheet(
                 element,
                 initWorkbook({ sheetType: "weighted" })
             );
-            console.log("network_weights")
         }
-        console.log("I am here!")
     }
 
     if (

--- a/server/controllers/network-sheet-parser.js
+++ b/server/controllers/network-sheet-parser.js
@@ -330,7 +330,10 @@ var parseNetworkSheet = function (sheet, network) {
 exports.workbookType = function (workbookFile) {
     let workbookType;
     for (const sheet of workbookFile) {
-        if (sheet.name.toLowerCase() === "network" || sheet.name.toLowerCase() === "network_optimized_weights") {
+        if (
+            sheet.name.toLowerCase() === "network" || 
+            sheet.name.toLowerCase() === "network_optimized_weights"
+        ) {
             const cellA1 = sheet.data[0][0];
 
             if (cellA1 === CELL_A1_GRN) {

--- a/server/controllers/network-sheet-parser.js
+++ b/server/controllers/network-sheet-parser.js
@@ -331,7 +331,7 @@ exports.workbookType = function (workbookFile) {
     let workbookType;
     for (const sheet of workbookFile) {
         if (
-            sheet.name.toLowerCase() === "network" || 
+            sheet.name.toLowerCase() === "network" ||
             sheet.name.toLowerCase() === "network_optimized_weights"
         ) {
             const cellA1 = sheet.data[0][0];
@@ -350,7 +350,6 @@ exports.workbookType = function (workbookFile) {
 };
 
 exports.networks = function (workbookFile) {
-    console.log("Made ittt")
     const networks = {
         network: {},
         networkOptimizedWeights: {},

--- a/web-client-classic/public/js/update-app.js
+++ b/web-client-classic/public/js/update-app.js
@@ -572,8 +572,6 @@ const checkWorkbookModeSettings = () => {
     }
 };
 
-
-
 $("body").on("click", () => {
     if (grnState.workbook) {
         if (grnState.mode === NETWORK_PPI_MODE) {

--- a/web-client-classic/public/js/update-app.js
+++ b/web-client-classic/public/js/update-app.js
@@ -555,9 +555,8 @@ const resetDemoDropdown = () => {
 };
 
 const checkWorkbookModeSettings = () => {
-    const hasExpression = hasExpressionData(grnState.workbook.expression);
 
-    if (grnState.mode === NETWORK_PPI_MODE || !hasExpression) {
+    if (grnState.mode === NETWORK_PPI_MODE) {
         grnState.nodeColoring.nodeColoringEnabled = false;
         grnState.nodeColoring.showMenu = true;
         grnState.colorOptimal = false;
@@ -567,12 +566,14 @@ const checkWorkbookModeSettings = () => {
     } else if (grnState.mode === NETWORK_GRN_MODE) {
         grnState.nodeColoring.nodeColoringEnabled = true;
         grnState.nodeColoring.showMenu = true;
-        grnState.colorOptimal = true;
+        grnState.colorOptimal = grnState.workbook.sheetType === "weighted";
         showNodeColoringMenus();
         showEdgeWeightOptions();
         updateModeViews();
     }
 };
+
+
 
 $("body").on("click", () => {
     if (grnState.workbook) {

--- a/web-client-classic/public/js/update-app.js
+++ b/web-client-classic/public/js/update-app.js
@@ -555,7 +555,6 @@ const resetDemoDropdown = () => {
 };
 
 const checkWorkbookModeSettings = () => {
-
     if (grnState.mode === NETWORK_PPI_MODE) {
         grnState.nodeColoring.nodeColoringEnabled = false;
         grnState.nodeColoring.showMenu = true;


### PR DESCRIPTION
Removed logic that attached default edge coloring enablement to whether or not expression data was present, and instead attached it to the network sheet type (which connects to if the "network_optimized_weights" tab is present). Also made it so that when edge weights data isn't present and the "Edge" nav/dropdown is disabled, the edge coloring is shown as disabled as well.