### PR TITLE
Fix AllianceMine URL in data_fetcher_service.py

### DIFF
--- a/database/network-database/data_services/data_fetcher_service.py
+++ b/database/network-database/data_services/data_fetcher_service.py
@@ -6,7 +6,7 @@ from io import StringIO
 
 class DataFetcherService(ABC):
     def __init__(self):
-        self.service = Service("https://www.alliancegenome.org/alliancemine/service")
+        self.service = Service("https://alliancemine.alliancegenome.org/alliancemine/service")
     
     @abstractmethod
     def fetch_data(self):


### PR DESCRIPTION
When setting up the development environment on my laptop, I encountered an error trying to load the network database with main.py.  It turns out that the AllianceMine URL changed since the last time I did this (2/11/26).  I found the new URL and replaced it in data_fetcher_service.py.  In the future, maybe we should make this configurable?