### PR TITLE
For #1439 - Made Demo 3 have Node Coloring Off by Default

### DIFF
--- a/web-client-classic/public/js/update-app.js
+++ b/web-client-classic/public/js/update-app.js
@@ -555,6 +555,9 @@ const resetDemoDropdown = () => {
 };
 
 const checkWorkbookModeSettings = () => {
+    // We check for expression data to make sure Demo 3 has node coloring off by default
+    const hasExpression = hasExpressionData(grnState.workbook.expression);
+
     if (grnState.mode === NETWORK_PPI_MODE) {
         grnState.nodeColoring.nodeColoringEnabled = false;
         grnState.nodeColoring.showMenu = true;
@@ -563,7 +566,7 @@ const checkWorkbookModeSettings = () => {
         hideEdgeWeightOptions();
         updateModeViews();
     } else if (grnState.mode === NETWORK_GRN_MODE) {
-        grnState.nodeColoring.nodeColoringEnabled = true;
+        grnState.nodeColoring.nodeColoringEnabled = hasExpression;
         grnState.nodeColoring.showMenu = true;
         grnState.colorOptimal = grnState.workbook.sheetType === "weighted";
         showNodeColoringMenus();


### PR DESCRIPTION
Edited the logic so that files that don't have expression data have node coloring off by default, even if they are GRNs - and ensured that the fix for issue 1273 stayed working as well.

Fixes [Issue #1439](https://github.com/users/dondi/projects/2/views/1?sliceBy%5Bvalue%5D=MilkaZek&pane=issue&itemId=173734151&issue=dondi%7CGRNsight%7C1439)