### PR TITLE
#1442 Fix import sif and graphml files

### DIFF
--- a/server/controllers/importers/sif.js
+++ b/server/controllers/importers/sif.js
@@ -156,10 +156,11 @@ module.exports = function (sif) {
         errors: errors,
         warnings: warnings,
         sheetType: workbookMeta.sheetType,
-        workbookType: workbookMeta.workbookType,
         positiveWeights: [],
         negativeWeights: [],
-        meta: {},
+        meta: {
+            data: workbookMeta,
+        },
         expression: {},
     });
 

--- a/test/import-sif-tests.js
+++ b/test/import-sif-tests.js
@@ -21,9 +21,15 @@ let expectedUnweightedGRNWorkbook = initWorkbook({
     positiveWeights: [],
     negativeWeights: [],
     sheetType: "unweighted",
-    meta: {},
+    meta: {
+        data: {
+            workbookType: constants.NETWORK_GRN_MODE,
+            sheetType: "unweighted",
+            warnings: null,
+            errors: [],
+        },
+    },
     expression: {},
-    workbookType: constants.NETWORK_GRN_MODE,
 });
 
 let expectedUnweightedPPIWorkbook = initWorkbook({
@@ -40,9 +46,15 @@ let expectedUnweightedPPIWorkbook = initWorkbook({
     positiveWeights: [],
     negativeWeights: [],
     sheetType: "unweighted",
-    meta: {},
+    meta: {
+        data: {
+            workbookType: constants.NETWORK_PPI_MODE,
+            sheetType: "unweighted",
+            warnings: null,
+            errors: [],
+        },
+    },
     expression: {},
-    workbookType: constants.NETWORK_PPI_MODE,
 });
 
 var expectedWeightedWorkbook = initWorkbook({
@@ -59,8 +71,14 @@ var expectedWeightedWorkbook = initWorkbook({
     positiveWeights: [],
     negativeWeights: [],
     sheetType: "weighted",
-    meta: {},
-    workbookType: constants.NETWORK_GRN_MODE,
+    meta: {
+        data: {
+            workbookType: constants.NETWORK_GRN_MODE,
+            sheetType: "weighted",
+            warnings: null,
+            errors: [],
+        },
+    },
     expression: {},
 });
 
@@ -80,9 +98,15 @@ var expectedUnweightedWorkbookWithCycle = initWorkbook({
     positiveWeights: [],
     negativeWeights: [],
     sheetType: "unweighted",
-    meta: {},
+    meta: {
+        data: {
+            workbookType: constants.NETWORK_GRN_MODE,
+            sheetType: "unweighted",
+            warnings: null,
+            errors: [],
+        },
+    },
     expression: {},
-    workbookType: constants.NETWORK_GRN_MODE,
 });
 
 var expectedWeightedWorkbookWithCycle = initWorkbook({
@@ -101,9 +125,15 @@ var expectedWeightedWorkbookWithCycle = initWorkbook({
     positiveWeights: [],
     negativeWeights: [],
     sheetType: "weighted",
-    meta: {},
+    meta: {
+        data: {
+            workbookType: constants.NETWORK_GRN_MODE,
+            sheetType: "weighted",
+            warnings: null,
+            errors: [],
+        },
+    },
     expression: {},
-    workbookType: constants.NETWORK_GRN_MODE,
 });
 
 // Unweighted SIF
@@ -313,6 +343,11 @@ describe("Import from SIF", function () {
         expect(importController.sifToGrnsight(inconsistentlyWeightedTestSif)).to.deep.equal(
             extend(true, {}, expectedUnweightedGRNWorkbook, {
                 warnings: [constants.warnings.EDGES_WITHOUT_WEIGHTS],
+                meta: {
+                    data: {
+                        warnings: constants.warnings.EDGES_WITHOUT_WEIGHTS,
+                    },
+                },
             })
         );
     });
@@ -335,6 +370,11 @@ describe("Import from SIF", function () {
         ).to.deep.equal(
             extend(true, {}, expectedUnweightedWorkbookWithCycle, {
                 warnings: [constants.warnings.EDGES_WITHOUT_WEIGHTS],
+                meta: {
+                    data: {
+                        warnings: constants.warnings.EDGES_WITHOUT_WEIGHTS,
+                    },
+                },
             })
         );
     });
@@ -356,9 +396,15 @@ describe("Import from SIF", function () {
                 positiveWeights: [],
                 negativeWeights: [],
                 sheetType: "unweighted",
-                meta: {},
+                meta: {
+                    data: {
+                        workbookType: constants.NETWORK_GRN_MODE,
+                        sheetType: "unweighted",
+                        warnings: null,
+                        errors: [],
+                    },
+                },
                 expression: {},
-                workbookType: constants.NETWORK_GRN_MODE,
             })
         );
     });
@@ -373,9 +419,15 @@ describe("Import from SIF", function () {
                 positiveWeights: [],
                 negativeWeights: [],
                 sheetType: "weighted",
-                meta: {},
+                meta: {
+                    data: {
+                        workbookType: constants.NETWORK_GRN_MODE,
+                        sheetType: "weighted",
+                        warnings: null,
+                        errors: [],
+                    },
+                },
                 expression: {},
-                workbookType: constants.NETWORK_GRN_MODE,
             })
         );
     });

--- a/web-client-classic/public/js/graph.js
+++ b/web-client-classic/public/js/graph.js
@@ -544,7 +544,7 @@ export var drawGraph = function (workbook) {
     }
 
     let uniqueLinks = [];
-    if (workbook.meta.data.workbookType === NETWORK_PPI_MODE) {
+    if (grnState.mode === NETWORK_PPI_MODE) {
         const seenLinks = {};
         workbook.links.forEach(function (link) {
             const sourceId = getLinkEndpointId(link.source);

--- a/web-client-classic/public/js/setup-load-and-import-handlers.js
+++ b/web-client-classic/public/js/setup-load-and-import-handlers.js
@@ -149,9 +149,10 @@ export const setupLoadAndImportHandlers = grnState => {
                 }
                 grnState.workbook = workbook;
 
-                grnState.mode = workbook.meta.data.workbookType;
                 if (grnState.name.includes(".graphml")) {
                     grnState.mode = NETWORK_GRN_MODE;
+                } else {
+                    grnState.mode = workbook.meta.data.workbookType;
                 }
 
                 grnState.workbook.expressionNames = Object.keys(workbook.expression).filter(

--- a/web-client-classic/public/js/setup-load-and-import-handlers.js
+++ b/web-client-classic/public/js/setup-load-and-import-handlers.js
@@ -148,13 +148,12 @@ export const setupLoadAndImportHandlers = grnState => {
                     }
                 }
                 grnState.workbook = workbook;
-                if (grnState.name.includes(".sif")) {
-                    grnState.mode = workbook.workbookType;
-                } else if (grnState.name.includes(".graphml")) {
+
+                grnState.mode = workbook.meta.data.workbookType;
+                if (grnState.name.includes(".graphml")) {
                     grnState.mode = NETWORK_GRN_MODE;
-                } else {
-                    grnState.mode = workbook.meta.data.workbookType;
                 }
+
                 grnState.workbook.expressionNames = Object.keys(workbook.expression).filter(
                     key => key !== "source"
                 );

--- a/web-client-classic/public/js/update-app.js
+++ b/web-client-classic/public/js/update-app.js
@@ -385,7 +385,7 @@ const enableNodeColoringUI = function () {
 
 const adjustGeneNameForExpression = function (gene) {
     const geneName = gene.name;
-    return grnState.workbook.meta.data.workbookType === NETWORK_PPI_MODE && geneName.endsWith("p")
+    return grnState.mode === NETWORK_PPI_MODE && geneName.endsWith("p")
         ? geneName.slice(0, -1)
         : geneName;
 };


### PR DESCRIPTION
Pull Request Checklist
- [x] Travis C.I. build passes
- [x] All five Demos look as expected when loaded
- [x] Reload works as expected
- [x] Load an Excel file (GRN and PPI)
- [X] Load a SIF file (GRN and PPI)
- [X] Load a GraphML file (GRN)
- [x] Loading file with Error brings up error modal, and it looks as expected
- [x] Loading file with Warning brings up warnings modal
- [x] Loading a network from the database looks as expected when loaded (GRN and PPI)
- [ ] Network can be exported to SIF (GRN and PPI) and GraphML (GRN-only)
- [x] Network, Expression data, and Additional Sheets can be exported to Excel
- [x] Image can be exported to PNG, SVG and PDF
- [x] Print works as expected
- [x] Restrict graph to viewport works as expected (check/uncheck)
- [x] Viewport Size Changing works as expected (small/medium/large/fit)
- [x] Toggle between Grid Layout and Force Graph Layout works as expected
- [x] Force Graph Parameter Sliders change the number above them and have an effect on the graph
- [x] Locking/Unlocking/Resetting/Undo Resetting the force graph parameters works as expected
- [x] Enabling and disabling node coloring works as expected
- [x] Node coloring options work as expected (selection top/bottom dataset, averaging values, changing max value)
- [x] Weighted graph loaded with the "Enable Edge Coloring" option checked appears as expected
- [x] Hide/Show Weights works as expected (always/never/upon mouseover)
- [x] Edge Weight Normalization Factor can be changed (set/reset)
- [x] Gray Edge Threshold can be changed, slider changes the number and has an effect on the graph
- [x] Checking Show Gray Edges as Dashed works as expected (check/uncheck)
- [x] D-pad left/right/top/bottom/center works as expected
- [x] Zoom slider changes number and has effect on graph (viewport and menu)
- [x] Right click on a node opens gene page, page is populated with correct data (currently broken, though)