### PR TITLE
Adding export warnings for optimized_threshold_b and optimized_produc…

### DIFF
--- a/web-client-classic/public/js/constants.js
+++ b/web-client-classic/public/js/constants.js
@@ -199,4 +199,10 @@ export const VIEWPORT_OPTION_CLASS_SIDEBAR = ".boundBoxSize";
 export const NETWORK_PPI_MODE = "protein-protein-physical-interaction";
 export const NETWORK_GRN_MODE = "grn";
 
-export const TWO_COLUMN_SHEETS = ["production_rates", "degradation_rates", "threshold_b"];
+export const TWO_COLUMN_SHEETS = [
+    "production_rates",
+    "degradation_rates",
+    "threshold_b",
+    "optimized_production_rates",
+    "optimized_threshold_b",
+];

--- a/web-client-classic/public/js/export-warning-constants.js
+++ b/web-client-classic/public/js/export-warning-constants.js
@@ -1,23 +1,48 @@
+const PROD_RATE_MSG =
+    "production rates from the backend database which are 2X the degradation rates reported in Neymotin et al. (2014)";
+const THRESHOLD_MSG = "the default value of 0 for each gene";
+
 const dataSourceForTwoColumnSheet = {
     degradation_rates: "degradation rates from the backend database from Neymotin et al. (2014)",
-    production_rates:
-        "production rates from the backend database which are 2X the degradation rates reported in Neymotin et al. (2014)",
-    threshold_b: "the default value of 0 for each gene",
+    production_rates: PROD_RATE_MSG,
+    optimized_production_rates: PROD_RATE_MSG,
+    threshold_b: THRESHOLD_MSG,
+    optimized_threshold_b: THRESHOLD_MSG,
+};
+
+const valuesForEachTwoColSheet = {
+    production_rates: "production rates",
+    optimized_production_rates: "production rates",
+    degradation_rates: "degradation rates",
+    threshold_b: "threshold b values",
+    optimized_threshold_b: "threshold b values",
+};
+
+const grnMapInputSuppliedWarningMessage = (sheetName, value) => {
+    const stringValue = String(value);
+
+    const msg = sheetName.includes("optimized")
+        ? `GRNsight is checking because ${stringValue} should have been provided as GRNmap output.`
+        : [
+              stringValue.charAt(0).toUpperCase() + stringValue.slice(1),
+              " will need to be supplied to use this workbook as an input file for GRNmap.",
+          ].join("");
+
+    return msg;
 };
 
 module.exports = {
     warnings: {
         // ADDITIONAL SHEET WARNINGS
         MISSING_DATABASE_RATES: function (sheetName, missingGenes = "") {
-            const displayName = sheetName.replace(/_/g, " ");
-            const singularName = displayName.replace(/s$/, "");
+            const value = valuesForEachTwoColSheet[sheetName] || "values";
 
             return {
                 warningCode: `MISSING_DATABASE_${sheetName.toUpperCase()}_EXPORT_WARNING`,
                 errorDescription: [
-                    `GRNsight has detected that there are missing ${displayName} in the exported workbook's "${sheetName}" sheet.`,
-                    `These ${displayName} are missing in our database.`,
-                    `A ${singularName} will need to be supplied to use this workbook as an input file for GRNmap.`,
+                    `GRNsight has detected that there are missing ${value} in the exported workbook's "${sheetName}" sheet.`,
+                    `These ${value} are missing in our database.`,
+                    `${grnMapInputSuppliedWarningMessage(sheetName, value)}`,
                     `The missing values are for the genes: ${missingGenes}.`,
                 ].join(" "),
             };

--- a/web-client-classic/public/js/upload.js
+++ b/web-client-classic/public/js/upload.js
@@ -405,6 +405,8 @@ export const upload = function () {
             production_rates: "ProductionRates",
             degradation_rates: "DegradationRates",
             threshold_b: "ThresholdB",
+            optimized_production_rates: "ProductionRates",
+            optimized_threshold_b: "ThresholdB",
         };
 
         const { chosenTwoColumnSheets, sheetsToFetch, warningsToAdd } =


### PR DESCRIPTION
…tion_rates

Pull Request Checklist
- [x] Travis C.I. build passes
- [x] All five Demos look as expected when loaded
- [x] Reload works as expected
- [x] Load an Excel file (GRN and PPI)
- [ ] Load a SIF file (GRN and PPI)
- [ ] Load a GraphML file (GRN)
- [x] Loading file with Error brings up error modal, and it looks as expected
- [x] Loading file with Warning brings up warnings modal
- [x] Loading a network from the database looks as expected when loaded (GRN and PPI)
- [ ] Network can be exported to SIF (GRN and PPI) and GraphML (GRN-only)
- [x] Network, Expression data, and Additional Sheets can be exported to Excel
- [x] Image can be exported to PNG, SVG and PDF
- [x] Print works as expected
- [x] Restrict graph to viewport works as expected (check/uncheck)
- [x] Viewport Size Changing works as expected (small/medium/large/fit)
- [x] Toggle between Grid Layout and Force Graph Layout works as expected
- [x] Force Graph Parameter Sliders change the number above them and have an effect on the graph
- [x] Locking/Unlocking/Resetting/Undo Resetting the force graph parameters works as expected
- [x] Enabling and disabling node coloring works as expected
- [x] Node coloring options work as expected (selection top/bottom dataset, averaging values, changing max value)
- [x] Weighted graph loaded with the "Enable Edge Coloring" option checked appears as expected
- [x] Hide/Show Weights works as expected (always/never/upon mouseover)
- [x] Edge Weight Normalization Factor can be changed (set/reset)
- [x] Gray Edge Threshold can be changed, slider changes the number and has an effect on the graph
- [x] Checking Show Gray Edges as Dashed works as expected (check/uncheck)
- [x] D-pad left/right/top/bottom/center works as expected
- [x] Zoom slider changes number and has effect on graph (viewport and menu)
- [x] Right click on a node opens gene page, page is populated with correct data (currently broken, though)