### PR TITLE
#1383: Zoom slider resets to 100% when switch between demos

### DIFF
--- a/web-client/package.json
+++ b/web-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-client",
   "private": true,
-  "version": "0.0.8",
+  "version": "0.0.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-client",
   "private": true,
-  "version": "0.0.10",
+  "version": "0.0.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web-client/src/components/Navbar.jsx
+++ b/web-client/src/components/Navbar.jsx
@@ -1,10 +1,12 @@
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { Nav, DropButton, Box, Text, Button, TextInput } from "grommet";
 import { Refresh, Checkmark, FolderOpen, CaretRightFill } from "grommet-icons";
 import { GrnStateContext } from "../App";
 import {
   DEMO_TYPES,
+  NETWORK_GRN_MODE_FULL,
   NETWORK_GRN_MODE_SHORT,
+  NETWORK_PPI_MODE_FULL,
   LIGHT_GREEN,
   LIGHT_GRAY,
   MEDIUM_GRAY,
@@ -74,6 +76,13 @@ export default function Navbar({}) {
     setAdaptive,
   } = useContext(GrnStateContext);
 
+  const isZoomControlDisabled =
+    networkMode !== NETWORK_GRN_MODE_FULL && networkMode !== NETWORK_PPI_MODE_FULL;
+
+  useEffect(() => {
+    setZoomTextInput(zoomPercent);
+  }, [zoomPercent]);
+
   const valueValidator = (min, max, value) => {
     return Math.min(max, Math.max(min, value));
   };
@@ -83,14 +92,32 @@ export default function Navbar({}) {
   };
 
   const handleZoomInputChange = event => {
-    setZoomPercent(zoomInputValidator(event.target.value));
-    setZoomTextInput(event.target.value);
+    const rawValue = event.target.value;
+    setZoomTextInput(rawValue);
+
+    // Let users clear the field while typing without snapping to min zoom.
+    if (rawValue === "") {
+      return;
+    }
+
+    const numericValue = Number(rawValue);
+    if (Number.isNaN(numericValue)) {
+      return;
+    }
+
+    setZoomPercent(zoomInputValidator(numericValue));
   };
 
   const handleDropContentClick = event => {
     if (event.target.closest(".demo-dropdown-navbar")) {
       return;
     }
+
+    // Allow focusing/typing in inputs without immediately closing the menu.
+    if (event.target.closest('input, textarea, [contenteditable="true"], [role="textbox"]')) {
+      return;
+    }
+
     setOpenMenu(null);
   };
 
@@ -474,10 +501,14 @@ export default function Navbar({}) {
 
             <DottedLine />
             <Box pad={{ horizontal: "20px", vertical: "3px" }} direction="row">
-              <Text>
+              <Text color={isZoomControlDisabled ? "#ccc" : undefined}>
                 Zoom ({ZOOM_DISPLAY_MINIMUM} - {ZOOM_DISPLAY_MAXIMUM})
               </Text>{" "}
-              <TextInput value={zoomTextInput} onChange={event => handleZoomInputChange(event)} />
+              <TextInput
+                value={zoomTextInput}
+                onChange={event => handleZoomInputChange(event)}
+                disabled={isZoomControlDisabled}
+              />
             </Box>
           </div>
         }

--- a/web-client/src/components/ScaleAndScroll.jsx
+++ b/web-client/src/components/ScaleAndScroll.jsx
@@ -1,4 +1,4 @@
-import { useContext, useState, useMemo, useRef } from "react";
+import { useContext, useEffect, useState, useRef } from "react";
 import { GrnStateContext } from "../App";
 import {
   ZOOM_DISPLAY_MINIMUM,
@@ -23,6 +23,27 @@ export default function ScaleAndScroll({ getViewportBoundsData }) {
   const frame = useRef(null);
   const [zoomSliderValue, setZoomSliderValue] = useState(null);
   const { zoomPercent, setZoomPercent, networkMode, adaptive } = useContext(GrnStateContext);
+
+  const mapPercentToSlider = percent => {
+    if (percent <= ZOOM_DISPLAY_MIDDLE) {
+      return (
+        ((percent - ZOOM_DISPLAY_MINIMUM) / (ZOOM_DISPLAY_MIDDLE - ZOOM_DISPLAY_MINIMUM)) *
+          (ZOOM_SLIDER_MIDDLE - ZOOM_SLIDER_MIN) +
+        ZOOM_SLIDER_MIN
+      );
+    }
+
+    return (
+      ((percent - ZOOM_DISPLAY_MIDDLE) / (ZOOM_DISPLAY_MAXIMUM - ZOOM_DISPLAY_MIDDLE)) *
+        (ZOOM_SLIDER_MAX - ZOOM_SLIDER_MIDDLE) +
+      ZOOM_SLIDER_MIDDLE
+    );
+  };
+
+  // Keep slider thumb position in sync when zoomPercent is changed externally.
+  useEffect(() => {
+    setZoomSliderValue(mapPercentToSlider(zoomPercent));
+  }, [zoomPercent]);
 
   const handleSliderChange = event => {
     const sliderInput = parseFloat(event.target.value);


### PR DESCRIPTION
- related to #1383 
- zoom slider resets to 100% when switch between demos.
- zoom text input in navbar matches the zoom input slider, and the slider matches the zoom text input.