### PR TITLE
Fixes Issue 1384 - Reset demo dropdown when non-demo file is loaded 

### DIFF
--- a/web-client-classic/public/js/setup-load-and-import-handlers.js
+++ b/web-client-classic/public/js/setup-load-and-import-handlers.js
@@ -169,6 +169,9 @@ export const setupLoadAndImportHandlers = grnState => {
                 reloader = () => loadGrn(name, formData);
                 // re-enable upload button
                 disableUpload(false);
+                if (demoFiles.indexOf(name) === -1) {
+                    grnState.demoDropdownValue = null;
+                }
                 updateApp(grnState);
                 // displayStatistics(workbook);
             })


### PR DESCRIPTION
Fixed by setting demoDropdownValue to null when a non-demo file is loaded in loadGrn, which sets the existing resetDemoDropdown() call in updateApp. The page-refresh case is now handled, since demoDropdownValue is initialized to null in grnState. 