### PR TITLE
Fixed Issue 1357 - Disable edge options when Edge Coloring is turned off 

### DIFF
--- a/web-client-classic/public/js/update-app.js
+++ b/web-client-classic/public/js/update-app.js
@@ -3,6 +3,7 @@ import { uploadState } from "./upload";
 import { displayGraphWarnings, displayPPINodeColorWarning } from "./warnings";
 import { max } from "d3-array";
 import { grnState } from "./grnstate";
+import { SET_NORMALIZATION_SIDEBAR, SET_NORMALIZATION_SIDEBAR_VALUE, RESET_NORMALIZATION_SIDEBAR } from "./constants";
 
 import {
     HOST_SITE,
@@ -1030,6 +1031,11 @@ export const updateApp = grnState => {
 
     if (grnState.workbook !== null && grnState.workbook.sheetType === "weighted") {
         showEdgeWeightOptions();
+        $(SET_NORMALIZATION_SIDEBAR_VALUE).prop("disabled", !grnState.colorOptimal);
+        $(SET_NORMALIZATION_SIDEBAR).prop("disabled", !grnState.colorOptimal);
+        $(RESET_NORMALIZATION_SIDEBAR).prop("disabled", !grnState.colorOptimal);
+        $(GREY_EDGE_THRESHOLD_SLIDER_SIDEBAR).prop("disabled", !grnState.colorOptimal);
+        $(GREY_EDGES_DASHED_SIDEBAR).prop("disabled", !grnState.colorOptimal);
     } else if (grnState.workbook !== null && grnState.workbook.sheetType === "unweighted") {
         hideEdgeWeightOptions();
     } else {

--- a/web-client-classic/public/js/update-app.js
+++ b/web-client-classic/public/js/update-app.js
@@ -3,7 +3,6 @@ import { uploadState } from "./upload";
 import { displayGraphWarnings, displayPPINodeColorWarning } from "./warnings";
 import { max } from "d3-array";
 import { grnState } from "./grnstate";
-import { SET_NORMALIZATION_SIDEBAR, SET_NORMALIZATION_SIDEBAR_VALUE, RESET_NORMALIZATION_SIDEBAR } from "./constants";
 
 import {
     HOST_SITE,
@@ -110,6 +109,9 @@ import {
     EXPORT_TO_UNWEIGHTED_GML_MENU,
     NETWORK_GRN_MODE,
     NETWORK_PPI_MODE,
+    SET_NORMALIZATION_SIDEBAR,
+    SET_NORMALIZATION_SIDEBAR_VALUE,
+    RESET_NORMALIZATION_SIDEBAR,
     //   EXPRESSION_SOURCE,
 } from "./constants";
 


### PR DESCRIPTION
Fixed by adding .prop("disabled", !grnState.colorOptimal) to the three sidebar elements inside the weighted workbook check in updateApp - since grnState.colorOptimal is tracking whether edge coloring is on or off, passing its negation to .prop("disabled" ...) automatically disables the elements when edge coloring is off and re-enables them when it is turned back on.