### PR TITLE
Fixed Issue 1375 - Network panel requires two clicks to collapse vertically

### DIFF
--- a/web-client-classic/views/upload.pug
+++ b/web-client-classic/views/upload.pug
@@ -325,7 +325,7 @@ html
         div(class="network panel panel-default")
             p(class='panel-title sidebarPanelHeader')
               a(data-toggle='collapse' data-target='#networkSidebarPanel') Network
-            div(id="networkSidebarPanel" class="panel-collapse")
+            div(id="networkSidebarPanel" class="panel-collapse collapse in")
               div(class="panel-body")
                 form(class='panelDropdownContainer')
                   p(class="network-source-section-title") Network Source


### PR DESCRIPTION
Fixed by adding collapse in to the class since collapse tells Bootstrap to manage the panel's toggle behavior, and in keeps it open by default when the page loads. The networkSidebarPanel div was missing the collapse class, causing it to fail to recognize the panel's initial state.  