### PR TITLE
Fixed Issue 1357 - Disable edge menu bar options when Edge Coloring is turned off

### DIFF
--- a/web-client-classic/public/js/update-app.js
+++ b/web-client-classic/public/js/update-app.js
@@ -112,6 +112,7 @@ import {
     SET_NORMALIZATION_SIDEBAR,
     SET_NORMALIZATION_SIDEBAR_VALUE,
     RESET_NORMALIZATION_SIDEBAR,
+    SET_NORMALIZATION_MENU,
     //   EXPRESSION_SOURCE,
 } from "./constants";
 
@@ -1038,6 +1039,10 @@ export const updateApp = grnState => {
         $(RESET_NORMALIZATION_SIDEBAR).prop("disabled", !grnState.colorOptimal);
         $(GREY_EDGE_THRESHOLD_SLIDER_SIDEBAR).prop("disabled", !grnState.colorOptimal);
         $(GREY_EDGES_DASHED_SIDEBAR).prop("disabled", !grnState.colorOptimal);
+        const edgeColoringFunc = !grnState.colorOptimal ? "addClass" : "removeClass";
+        $(".weightedGraphOptionsMenu.edge-coloring-dependent")[edgeColoringFunc]("disabled");
+        $(SET_NORMALIZATION_MENU).prop("disabled", !grnState.colorOptimal);
+        $(GREY_EDGE_THRESHOLD_MENU).prop("disabled", !grnState.colorOptimal);
     } else if (grnState.workbook !== null && grnState.workbook.sheetType === "unweighted") {
         hideEdgeWeightOptions();
     } else {

--- a/web-client-classic/views/upload.pug
+++ b/web-client-classic/views/upload.pug
@@ -158,23 +158,23 @@ html
                     span(class='glyphicon')
                     | &nbsp; Never Show Edge Weights
                 li(class='divider')
-                li(class='weightedGraphOptionsMenu disabled')
+                li(class='weightedGraphOptionsMenu disabled edge-coloring-dependent')
                   a(href='#' class='with-input')
                     span(class='glyphicon invisible')
                     | &nbsp; Edge Weight Normalization Factor (0.0001 - 1000) &nbsp;
                     input(type='number' id='edge-weight-normalization-factor-menu' class='keepopen' placeholder='' step='0.0001' aria-describedby='basic-addon1')
-                li(class='weightedGraphOptionsMenu disabled')
+                li(class='weightedGraphOptionsMenu disabled edge-coloring-dependent')
                   a(href='#' id='reset-normalization-factor-menu')
                     span(class='glyphicon invisible')
                     | &nbsp; Reset Edge Weight Normalization Factor
                 li(class='divider')
-                li(class='weightedGraphOptionsMenu disabled')
+                li(class='weightedGraphOptionsMenu disabled edge-coloring-dependent')
                   a(href='#' class='with-input')
                     span(class='glyphicon invisible')
                     | &nbsp; Gray Edge Threshold (0 - 100%) &nbsp;
                     input(type='number' id='gray-edge-threshold-menu' class='keepopen' value='5' aria-describedby='basic-addon1')
                     | %
-                li(class='weightedGraphOptionsMenu disabled')
+                li(class='weightedGraphOptionsMenu disabled edge-coloring-dependent')
                   a(href='#' id='grey-edges-dashed-menu')
                     span(class='glyphicon')
                     | &nbsp; Show Gray Edges as Dashed


### PR DESCRIPTION
Fixed by extending the disable logic in update-app.js to the menu bar elements in addition to the sidebar. edge-coloring-dependent was added as a class to the relevant li elements in upload.pug to allow the menu bar anchor tag items to be toggled. 