### PR TITLE
#1587 implement naming for .png, .pdf, .svg exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ Backup of *.doc*
 .env
 web-client/.vite/deps/
 dist/
+web-client-classic/public/js/vendors-node_modules_canvg*
 
 # Ignore Python __pycache__ folder
 __pycache__/.nyc_output/

--- a/web-client-classic/public/js/setup-handlers.js
+++ b/web-client-classic/public/js/setup-handlers.js
@@ -190,7 +190,6 @@ export const setupHandlers = grnState => {
         }
 
         let canvas = document.createElement("canvas");
-        //canvg(canvas, svgElement);
         const ctx = canvas.getContext("2d");
         const v = await Canvg.fromString(ctx, svgElement);
         await v.render();

--- a/web-client-classic/public/js/setup-handlers.js
+++ b/web-client-classic/public/js/setup-handlers.js
@@ -1,8 +1,9 @@
 import { updaters } from "./graph";
 import { updateApp, identifySpeciesMenu } from "./update-app";
 import { saveSvgAsPng } from "save-svg-as-png";
-import * as jsPDF from "jspdf";
-import canvg from "canvg";
+import { jsPDF } from "jspdf";
+import { Canvg } from "canvg";
+import { filenameWithExtension } from "./upload";
 
 import {
     HOST_SITE,
@@ -183,13 +184,17 @@ export const setupHandlers = grnState => {
         $("#exportAsSvg").attr("download", name);
     };
 
-    const exportPDF = (svgElement, name) => {
+    const exportPDF = async (svgElement, name) => {
         if (svgElement) {
             svgElement = svgElement.replace(/\r?\n|\r/g, "").trim();
         }
 
         let canvas = document.createElement("canvas");
-        canvg(canvas, svgElement);
+        //canvg(canvas, svgElement);
+        const ctx = canvas.getContext("2d");
+        const v = await Canvg.fromString(ctx, svgElement);
+        await v.render();
+
         const imgData = canvas.toDataURL("image/png");
 
         const pdf = new jsPDF("l", "mm", "letter");
@@ -236,19 +241,37 @@ export const setupHandlers = grnState => {
     // Image Export
     $(EXPORT_TO_PNG).click(() => {
         var svgContainer = document.getElementById("exportContainer");
-        var editedName = grnState.name.replace(determineFileType(grnState.name), "") + ".png";
+        var editedName = filenameWithExtension(
+            grnState.mode,
+            grnState.workbook.genes.length,
+            grnState.workbook.links.length,
+            null,
+            "png"
+        );
         saveSvgAsPng(svgContainer, editedName, { backgroundColor: "white" });
     });
 
     $(EXPORT_TO_SVG).click(() => {
         var svgContainer = document.getElementById("exportContainer");
-        var editedName = grnState.name.replace(determineFileType(grnState.name), "") + ".svg";
+        var editedName = filenameWithExtension(
+            grnState.mode,
+            grnState.workbook.genes.length,
+            grnState.workbook.links.length,
+            null,
+            "svg"
+        );
         exportSVG(svgContainer, editedName);
     });
 
-    $(EXPORT_TO_PDF).click(() => {
+    $(EXPORT_TO_PDF).click(async () => {
         var svgContainer = document.getElementById("exportContainer").innerHTML;
-        var editedName = grnState.name.replace(determineFileType(grnState.name), "") + ".pdf";
+        var editedName = filenameWithExtension(
+            grnState.mode,
+            grnState.workbook.genes.length,
+            grnState.workbook.links.length,
+            null,
+            "pdf"
+        );
         exportPDF(svgContainer, editedName);
     });
 

--- a/web-client-classic/public/js/upload.js
+++ b/web-client-classic/public/js/upload.js
@@ -47,6 +47,41 @@ export const uploadState = {
     currentWorkbook: null,
 };
 
+export const filenameWithExtension = function (mode, genes, edges, type, extension) {
+    var filename = $("#fileName").text();
+    var source = null;
+    var currentExtension = filename.match(/\.[^\.]+$/);
+    if (currentExtension && currentExtension.length) {
+        filename = filename.substr(0, filename.length - currentExtension[0].length);
+    }
+    if (mode === NETWORK_GRN_MODE && extension === "xlsx") {
+        source = $("input[name=expressionSource]:checked")[0].value;
+        if (source === "none") {
+            source = null;
+        } else if (source === "userInput") {
+            // only demos will have an expression source
+            source = grnState.workbook.expression.source
+                ? grnState.workbook.expression.source
+                : "user-data";
+        }
+    }
+
+    if (mode !== NETWORK_GRN_MODE) {
+        mode = "PPI";
+    }
+    if (mode !== null && genes !== null && edges !== null) {
+        if (type !== null) {
+            filename = `${mode.toUpperCase()}_${genes}-genes_${edges}-edges_${type}`;
+        } else {
+            filename = `${mode.toUpperCase()}_${genes}-genes_${edges}-edges`;
+        }
+    }
+    if (source) {
+        filename = `${filename}_${source}`;
+    }
+    return `${filename}.${extension}`;
+};
+
 export const upload = function () {
     // Values
     var TOOLTIP_SHOW_DELAY = 700;
@@ -88,37 +123,6 @@ export const upload = function () {
             delete link.weightElement;
         });
         return result;
-    };
-
-    var filenameWithExtension = function (mode, genes, edges, type, extension) {
-        var filename = $("#fileName").text();
-        var source = null;
-        var currentExtension = filename.match(/\.[^\.]+$/);
-        if (currentExtension && currentExtension.length) {
-            filename = filename.substr(0, filename.length - currentExtension[0].length);
-        }
-        if (mode === NETWORK_GRN_MODE && extension === "xlsx") {
-            source = $("input[name=expressionSource]:checked")[0].value;
-            if (source === "none") {
-                source = null;
-            } else if (source === "userInput") {
-                // only demos will have an expression source
-                source = grnState.workbook.expression.source
-                    ? grnState.workbook.expression.source
-                    : "user-data";
-            }
-        }
-
-        if (mode !== NETWORK_GRN_MODE) {
-            mode = "PPI";
-        }
-        if (mode !== null && genes !== null && edges !== null && type !== null) {
-            filename = `${mode.toUpperCase()}_${genes}-genes_${edges}-edges_${type}`;
-        }
-        if (source) {
-            filename = `${filename}_${source}`;
-        }
-        return `${filename}.${extension}`;
     };
 
     const download = (workbook, route, extension, sheetType) => {


### PR DESCRIPTION
- moved filenameWithExtension outside of upload function, so png, pdf, and svg can use it 
- changed hardcode of png, pdf, and svg to include filenamewithExtension to have consistent naming 
- changed exportpdf to async to match with Canvg version 3, so it can export pdf for GRN. export ppi still doesn't work
- added canvg git ignore file because when I changed the Canvg code to update it, a new file appeared 

