### PR TITLE
#1587 .png, .pdf, .svg export file naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ Backup of *.doc*
 .env
 web-client/.vite/deps/
 dist/
+web-client-classic/public/js/vendors-node_modules_canvg*
 
 # Ignore Python __pycache__ folder
 __pycache__/.nyc_output/

--- a/web-client-classic/public/js/setup-handlers.js
+++ b/web-client-classic/public/js/setup-handlers.js
@@ -4,6 +4,7 @@ import { saveSvgAsPng } from "save-svg-as-png";
 import { jsPDF } from "jspdf";
 import { Canvg } from "canvg";
 import { filenameWithExtension } from "./upload";
+import { determineWorkbookType } from "./upload";
 
 import {
     HOST_SITE,
@@ -244,7 +245,7 @@ export const setupHandlers = grnState => {
             grnState.mode,
             grnState.workbook.genes.length,
             grnState.workbook.links.length,
-            null,
+            determineWorkbookType(),
             "png"
         );
         saveSvgAsPng(svgContainer, editedName, { backgroundColor: "white" });
@@ -256,7 +257,7 @@ export const setupHandlers = grnState => {
             grnState.mode,
             grnState.workbook.genes.length,
             grnState.workbook.links.length,
-            null,
+            determineWorkbookType(),
             "svg"
         );
         exportSVG(svgContainer, editedName);
@@ -268,7 +269,7 @@ export const setupHandlers = grnState => {
             grnState.mode,
             grnState.workbook.genes.length,
             grnState.workbook.links.length,
-            null,
+            determineWorkbookType(),
             "pdf"
         );
         exportPDF(svgContainer, editedName);

--- a/web-client-classic/public/js/setup-handlers.js
+++ b/web-client-classic/public/js/setup-handlers.js
@@ -190,7 +190,6 @@ export const setupHandlers = grnState => {
         }
 
         let canvas = document.createElement("canvas");
-        //canvg(canvas, svgElement);
         const ctx = canvas.getContext("2d");
         const v = await Canvg.fromString(ctx, svgElement);
         await v.render();

--- a/web-client-classic/public/js/setup-handlers.js
+++ b/web-client-classic/public/js/setup-handlers.js
@@ -1,8 +1,9 @@
 import { updaters } from "./graph";
 import { updateApp, identifySpeciesMenu } from "./update-app";
 import { saveSvgAsPng } from "save-svg-as-png";
-import * as jsPDF from "jspdf";
-import canvg from "canvg";
+import { jsPDF } from "jspdf";
+import { Canvg } from "canvg";
+import { filenameWithExtension } from "./upload";
 
 import {
     HOST_SITE,
@@ -183,13 +184,17 @@ export const setupHandlers = grnState => {
         $("#exportAsSvg").attr("download", name);
     };
 
-    const exportPDF = (svgElement, name) => {
+    const exportPDF = async (svgElement, name) => {
         if (svgElement) {
             svgElement = svgElement.replace(/\r?\n|\r/g, "").trim();
         }
 
         let canvas = document.createElement("canvas");
-        canvg(canvas, svgElement);
+        //canvg(canvas, svgElement);
+        const ctx = canvas.getContext("2d");
+        const v = await Canvg.fromString(ctx, svgElement);
+        await v.render();
+
         const imgData = canvas.toDataURL("image/png");
 
         const pdf = new jsPDF("l", "mm", "letter");
@@ -236,19 +241,37 @@ export const setupHandlers = grnState => {
     // Image Export
     $(EXPORT_TO_PNG).click(() => {
         var svgContainer = document.getElementById("exportContainer");
-        var editedName = grnState.name.replace(determineFileType(grnState.name), "") + ".png";
+        var editedName = filenameWithExtension(
+            grnState.mode,
+            grnState.workbook.genes.length,
+            grnState.workbook.links.length,
+            null,
+            "png"
+        );
         saveSvgAsPng(svgContainer, editedName, { backgroundColor: "white" });
     });
 
     $(EXPORT_TO_SVG).click(() => {
         var svgContainer = document.getElementById("exportContainer");
-        var editedName = grnState.name.replace(determineFileType(grnState.name), "") + ".svg";
+        var editedName = filenameWithExtension(
+            grnState.mode,
+            grnState.workbook.genes.length,
+            grnState.workbook.links.length,
+            null,
+            "svg"
+        );
         exportSVG(svgContainer, editedName);
     });
 
-    $(EXPORT_TO_PDF).click(() => {
+    $(EXPORT_TO_PDF).click(async () => {
         var svgContainer = document.getElementById("exportContainer").innerHTML;
-        var editedName = grnState.name.replace(determineFileType(grnState.name), "") + ".pdf";
+        var editedName = filenameWithExtension(
+            grnState.mode,
+            grnState.workbook.genes.length,
+            grnState.workbook.links.length,
+            null,
+            "pdf"
+        );
         exportPDF(svgContainer, editedName);
     });
 

--- a/web-client-classic/public/js/upload.js
+++ b/web-client-classic/public/js/upload.js
@@ -82,6 +82,18 @@ export const filenameWithExtension = function (mode, genes, edges, type, extensi
     return `${filename}.${extension}`;
 };
 
+export const determineWorkbookType = function () {
+    const workbookSheets = $("input[name=workbookSheets]:checked");
+    for (const [key, value] of Object.entries(workbookSheets)) {
+        if (!isNaN(parseInt(key, 10))) {
+            if (value.value === "network_optimized_weights") {
+                return "weighted";
+            }
+        }
+    }
+    return "unweighted";
+};
+
 export const upload = function () {
     // Values
     var TOOLTIP_SHOW_DELAY = 700;
@@ -471,18 +483,6 @@ export const upload = function () {
         finalExportSheets = await fetchTwoColumnSheets(finalExportSheets, chosenSheets, source);
 
         handleExpressionDataAndExport(route, extension, sheetType, source, finalExportSheets);
-    };
-
-    const determineWorkbookType = function () {
-        const workbookSheets = $("input[name=workbookSheets]:checked");
-        for (const [key, value] of Object.entries(workbookSheets)) {
-            if (!isNaN(parseInt(key, 10))) {
-                if (value.value === "network_optimized_weights") {
-                    return "weighted";
-                }
-            }
-        }
-        return "unweighted";
     };
 
     var performExport = function (route, extension, sheetType, source) {

--- a/web-client-classic/public/js/upload.js
+++ b/web-client-classic/public/js/upload.js
@@ -47,6 +47,41 @@ export const uploadState = {
     currentWorkbook: null,
 };
 
+export const filenameWithExtension = function (mode, genes, edges, type, extension) {
+    var filename = $("#fileName").text();
+    var source = null;
+    var currentExtension = filename.match(/\.[^\.]+$/);
+    if (currentExtension && currentExtension.length) {
+        filename = filename.substr(0, filename.length - currentExtension[0].length);
+    }
+    if (mode === NETWORK_GRN_MODE && extension === "xlsx") {
+        source = $("input[name=expressionSource]:checked")[0].value;
+        if (source === "none") {
+            source = null;
+        } else if (source === "userInput") {
+            // only demos will have an expression source
+            source = grnState.workbook.expression.source
+                ? grnState.workbook.expression.source
+                : "user-data";
+        }
+    }
+
+    if (mode !== NETWORK_GRN_MODE) {
+        mode = "PPI";
+    }
+    if (mode !== null && genes !== null && edges !== null) {
+        if (type !== null) {
+            filename = `${mode.toUpperCase()}_${genes}-genes_${edges}-edges_${type}`;
+        } else {
+            filename = `${mode.toUpperCase()}_${genes}-genes_${edges}-edges`;
+        }
+    }
+    if (source) {
+        filename = `${filename}_${source}`;
+    }
+    return `${filename}.${extension}`;
+};
+
 export const upload = function () {
     // Values
     var TOOLTIP_SHOW_DELAY = 700;
@@ -88,37 +123,6 @@ export const upload = function () {
             delete link.weightElement;
         });
         return result;
-    };
-
-    var filenameWithExtension = function (mode, genes, edges, type, extension) {
-        var filename = $("#fileName").text();
-        var source = null;
-        var currentExtension = filename.match(/\.[^\.]+$/);
-        if (currentExtension && currentExtension.length) {
-            filename = filename.substr(0, filename.length - currentExtension[0].length);
-        }
-        if (mode === NETWORK_GRN_MODE && extension === "xlsx") {
-            source = $("input[name=expressionSource]:checked")[0].value;
-            if (source === "none") {
-                source = null;
-            } else if (source === "userInput") {
-                // only demos will have an expression source
-                source = grnState.workbook.expression.source
-                    ? grnState.workbook.expression.source
-                    : "user-data";
-            }
-        }
-
-        if (mode !== NETWORK_GRN_MODE) {
-            mode = "PPI";
-        }
-        if (mode !== null && genes !== null && edges !== null && type !== null) {
-            filename = `${mode.toUpperCase()}_${genes}-genes_${edges}-edges_${type}`;
-        }
-        if (source) {
-            filename = `${filename}_${source}`;
-        }
-        return `${filename}.${extension}`;
     };
 
     const download = (workbook, route, extension, sheetType) => {


### PR DESCRIPTION

Pull Request Checklist
- [x] GitHub Actions C.I. build passes
- [x] All five Demos look as expected when loaded
- [x] Reload works as expected
- [x] Load an Excel file (GRN and PPI)
- [x] Load a SIF file (GRN and PPI)
- [x] Load a GraphML file (GRN)
- [x] Loading file with Error brings up error modal, and it looks as expected
- [x] Loading file with Warning brings up warnings modal
- [x] Loading a network from the database looks as expected when loaded (GRN and PPI)
- [x] Network can be exported to SIF (GRN and PPI) and GraphML (GRN-only)
- [x] Network, Expression data, and Additional Sheets can be exported to Excel
- [ ] Image can be exported to PNG, SVG and PDF
- [x] Print works as expected
- [x] Restrict graph to viewport works as expected (check/uncheck)
- [x] Viewport Size Changing works as expected (small/medium/large/fit)
- [x] Toggle between Grid Layout and Force Graph Layout works as expected
- [x] Force Graph Parameter Sliders change the number above them and have an effect on the graph
- [x] Locking/Unlocking/Resetting/Undo Resetting the force graph parameters works as expected
- [x] Enabling and disabling node coloring works as expected
- [x] Node coloring options work as expected (selection top/bottom dataset, averaging values, changing max value)
- [x] Weighted graph loaded with the "Enable Edge Coloring" option checked appears as expected
- [x] Hide/Show Weights works as expected (always/never/upon mouseover)
- [x] Edge Weight Normalization Factor can be changed (set/reset)
- [x] Gray Edge Threshold can be changed, slider changes the number and has an effect on the graph
- [x] Checking Show Gray Edges as Dashed works as expected (check/uncheck)
- [x] D-pad left/right/top/bottom/center works as expected
- [x] Zoom slider changes number and has effect on graph (viewport and menu)
- [x] Right click on a node opens gene page, page is populated with correct data (currently broken, though)
