### PR TITLE
#1384 demo dropdown in firefox refreshes to select a demo

### DIFF
--- a/web-client-classic/views/upload.pug
+++ b/web-client-classic/views/upload.pug
@@ -332,7 +332,7 @@ html
                   div(class="network-source-section")
                     form(class='panelDropdownContainer')
                       label(for='speciesDropdown' class='info') Demo
-                      select(class="DemoSourceDropdown panelDropdown btn btn-default" id='demoSourceDropdown' href='#')
+                      select(class="DemoSourceDropdown panelDropdown btn btn-default" id='demoSourceDropdown' href='#', autocomplete="off")
                         option(value="none" selected="true" disabled hidden) Select a Demo
                         option(href='#' id='demoSourceDropdown-unweighted' class='unweighted' value='unweighted') Demo #1: Unweighted GRN (15 genes, 28 edges, Dahlquist Lab unpublished data)
                         option(href='#' id='demoSourceDropdown-weighted' class='weighted' value='weighted')  Demo #2: Weighted GRN (15 genes, 28 edges, Dahlquist Lab unpublished data)


### PR DESCRIPTION

Pull Request Checklist
- [x] GitHub Actions C.I. build passes
- [x] All five Demos look as expected when loaded
- [x] Reload works as expected
- [x] Load an Excel file (GRN and PPI)
- [x] Load a SIF file (GRN and PPI)
- [x] Load a GraphML file (GRN)
- [x] Loading file with Error brings up error modal, and it looks as expected
- [x] Loading file with Warning brings up warnings modal
- [x] Loading a network from the database looks as expected when loaded (GRN and PPI)
- [x] Network can be exported to SIF (GRN and PPI) and GraphML (GRN-only)
- [x] Network, Expression data, and Additional Sheets can be exported to Excel
- [ ] Image can be exported to PNG, SVG and PDF
- [x] Print works as expected
- [x] Restrict graph to viewport works as expected (check/uncheck)
- [x] Viewport Size Changing works as expected (small/medium/large/fit)
- [x] Toggle between Grid Layout and Force Graph Layout works as expected
- [x] Force Graph Parameter Sliders change the number above them and have an effect on the graph
- [x] Locking/Unlocking/Resetting/Undo Resetting the force graph parameters works as expected
- [x] Enabling and disabling node coloring works as expected
- [x] Node coloring options work as expected (selection top/bottom dataset, averaging values, changing max value)
- [x] Weighted graph loaded with the "Enable Edge Coloring" option checked appears as expected
- [x] Hide/Show Weights works as expected (always/never/upon mouseover)
- [x] Edge Weight Normalization Factor can be changed (set/reset)
- [x] Gray Edge Threshold can be changed, slider changes the number and has an effect on the graph
- [x] Checking Show Gray Edges as Dashed works as expected (check/uncheck)
- [x] D-pad left/right/top/bottom/center works as expected
- [x] Zoom slider changes number and has effect on graph (viewport and menu)
- [x] Right click on a node opens gene page, page is populated with correct data (currently broken, though)
