### PR TITLE
Updated warning message to account for issue #1557

### DIFF
--- a/web-client-classic/public/js/export-warning-constants.js
+++ b/web-client-classic/public/js/export-warning-constants.js
@@ -55,7 +55,7 @@ module.exports = {
                 warningCode: `MISSING_OR_EMPTY_${sheetName.toUpperCase()}_SHEET`,
                 errorDescription: [
                     isMissing
-                        ? `There was no "${sheetName}" sheet in the imported workbook.`
+                        ? `There was no "${sheetName}" sheet in the exported workbook.`
                         : `The "${sheetName}" sheet was empty in the exported workbook.`,
                     prefix
                         ? `GRNsight is checking because a ${sheetName.split("_")[1] + " " + sheetName.split("_")[2]} value should have been provided as GRNmap output, but will not affect the display of the graph in GRNsight.`
@@ -71,7 +71,7 @@ module.exports = {
                 errorDescription: [
                     `There were no ${missingType} supplied`,
                     `in the "${sheetName}" sheet in the exported workbook.`,
-                    `GRNsight has supplied ${dataSourceForTwoColumnSheet[sheetName]}.`,
+                    `GRNsight is checking because a ${sheetName.split("_")[0] + " " + sheetName.split("_")[1]} value should have been provided as GRNmap output, but will not affect the display of the graph in GRNsight.`,
                 ].join(" "),
             };
         },

--- a/web-client-classic/public/js/export-warning-constants.js
+++ b/web-client-classic/public/js/export-warning-constants.js
@@ -66,13 +66,24 @@ module.exports = {
 
         MISSING_ALL_GENES_AND_VALUES: function (sheetName, isAllGenesMissing) {
             const missingType = isAllGenesMissing ? "genes and values" : "values";
+            const sheetNameSegments = sheetName.split("_");
+            const prefix = sheetName.includes("optimized");
             return {
                 warningCode: `MISSING_ALL_${missingType.toUpperCase()}_${sheetName.toUpperCase()}`,
-                errorDescription: [
-                    `There were no ${missingType} supplied`,
-                    `in the "${sheetName}" sheet in the exported workbook.`,
-                    `GRNsight is checking because a ${sheetName.split("_")[0] + " " + sheetName.split("_")[1]} value should have been provided as GRNmap output, but will not affect the display of the graph in GRNsight.`,
-                ].join(" "),
+                errorDescription: prefix
+                    ? [
+                          `There were no ${missingType} supplied`,
+                          `in the "${sheetName}" sheet in the exported workbook.`,
+                          "GRNsight is checking",
+                          `because a ${sheetNameSegments[0]} ${sheetNameSegments[1]} value`,
+                          "should have been provided as GRNmap output,",
+                          "but will not affect the display of the graph in GRNsight.",
+                      ].join(" ")
+                    : [
+                          `There were no ${missingType} supplied`,
+                          `in the "${sheetName}" sheet in the exported workbook.`,
+                          `GRNsight has supplied ${dataSourceForTwoColumnSheet[sheetName]}.`,
+                      ].join(" "),
             };
         },
 


### PR DESCRIPTION
Whenever a user attempts to export a file that is missing any data from any of the two column sheets, instead of being told that anything is being entered now, they are told that data is missing. This is a more accurate warning than what was being displayed before.