### PR TITLE
#1387 Correctly branching from beta 

### DIFF
--- a/database/schema/README.md
+++ b/database/schema/README.md
@@ -23,10 +23,6 @@ For example, to access your local PostgreSQL database, use the following command
 ```
 psql postgresql://localhost/postgres
 ```
-or
-```
-psql -U postgres postgresql://localhost/postgres
-```
 
 ## Creating Schemas and Adding Table Specifications
 
@@ -39,11 +35,11 @@ GRNsight requires six schemas, one for each of the following namespaces:
 5. `gene_regulatory_network` (this is the old schema for the gene regulatory network database before 2025 - this namepsace can be empty because we no longer load data into this namespace)
 6. `protein_protein_interactions` (this is the old schema for the protein protein interactions database before 2025 - this namepsace can be empty because we no longer load data into this namespace)
 
-The scripts already contain the commands to create the schemas for you. Each schema requires a set of table definitions. You can add these by running the following commands, each corresponding to an SQL file that defines the structure for each schema.
+The scripts already contain the command to create the schema for you. Each schema requires a set of table definitions. You can add these by running the following commands, each corresponding to an SQL file that defines the structure for each schema.
 
 First, outside of postgres, navigate to the `schema` folder in your local copy of the GRNsight repository:
 ```
-cd <path to schema folder>
+cd <path to `schema` folder>
 ```
 
 Then run the following commands. Note that for any command that begins with `psql`, you need to be _outside_ of postgres to run it. Also, you may need to specify the database username in front of localhost, i.e., use `postgresql://postgres@localhost/postgres` for each of the following commands.
@@ -77,9 +73,9 @@ Once these steps are completed, your database will be set up and ready to accept
 
 ### 1. Settings Database
 
-The `settings` table stores the default expression dataset name that is used for the node coloring dropdown menu in GRNsight.
+The `settings` table stores the default database name for the node coloring dropdown menu. Question: is this optional?
 
-You need to change the default expression dataset name by following these steps:
+To change the default database name, follow these steps:
 
 1. **Log in to the Database**
 
@@ -95,19 +91,19 @@ You need to change the default expression dataset name by following these steps:
 
 3. **Delete the Current Default Database Name**
 
-    Delete the existing expression dataset name with this command:
+    Delete the existing database name with this command:
 
     ```
     DELETE FROM grnsettings;
     ```
 
-4. **Insert the New Default Expression Dataset Name**  
-   Insert the new default dataset name with the following command:
+4. **Insert the New Default Database Name**  
+   Insert the new default database name with the following command:
     ```
-    INSERT INTO grnsettings(expression_dataset) VALUES ('<new default dataset name>');
+    INSERT INTO grnsettings(expression_dataset) VALUES ('<new default database name>');
     ```
-    _Note: The current default expression dataset is `dahlquist_2018`. Don't forget!_
+    _Note: The current default database is `dahlquist_2018`. Don't forget!_
 
 ### 2. Other databases
 
-For other databases, continue follow the instructions in the [README.md](https://github.com/dondi/GRNsight/tree/main/database/README.md#3-populate-data-into-database) outside of this directory.
+For other databases, continue follow the instructions in the [README.md](https://github.com/dondi/GRNsight/tree/main/database) outside of this directory.

--- a/web-client-classic/public/js/upload.js
+++ b/web-client-classic/public/js/upload.js
@@ -526,7 +526,10 @@ export const upload = function () {
                         <label for='exportExcelExpressionSource-noneRadio' id='exportExcelExpressionSource-none' class='export-radio-label'>None</label>
                     </li>
     `;
-        if (Object.keys(grnState.workbook.expression).length > 0) {
+        if (
+            Object.keys(grnState.workbook.expression).length > 0 &&
+            grnState.workbook.expression.hasOwnProperty("source")
+        ) {
             const isChecked = grnState.nodeColoring.nodeColoringEnabled ? `checked="true"` : "";
             result += `
                         <li>

--- a/web-client-classic/public/js/upload.js
+++ b/web-client-classic/public/js/upload.js
@@ -55,14 +55,24 @@ export const filenameWithExtension = function (mode, genes, edges, type, extensi
         filename = filename.substr(0, filename.length - currentExtension[0].length);
     }
     if (mode === NETWORK_GRN_MODE && extension === "xlsx") {
-        source = $("input[name=expressionSource]:checked")[0].value;
-        if (source === "none") {
+        const anyExpressionChecked = $("input[name=workbookSheets]:checked")
+            .toArray()
+            .some(
+                el => el.value && (el.value.includes("expression") || el.value.includes("sigma"))
+            );
+
+        if (anyExpressionChecked) {
+            source = $("input[name=expressionSource]:checked")[0].value;
+            if (source === "none") {
+                source = null;
+            } else if (source === "userInput") {
+                // only demos will have an expression source
+                source = grnState.workbook.expression.source
+                    ? grnState.workbook.expression.source
+                    : "user-data";
+            }
+        } else {
             source = null;
-        } else if (source === "userInput") {
-            // only demos will have an expression source
-            source = grnState.workbook.expression.source
-                ? grnState.workbook.expression.source
-                : "user-data";
         }
     }
 


### PR DESCRIPTION

Pull Request Checklist
- [x] GitHub Actions C.I. build passes
- [x] All five Demos look as expected when loaded
- [x] Reload works as expected
- [x] Load an Excel file (GRN and PPI)
- [x] Load a SIF file (GRN and PPI)
- [x] Load a GraphML file (GRN)
- [x] Loading file with Error brings up error modal, and it looks as expected
- [x] Loading file with Warning brings up warnings modal
- [x] Loading a network from the database looks as expected when loaded (GRN and PPI)
- [x] Network can be exported to SIF (GRN and PPI) and GraphML (GRN-only)
- [x] Network, Expression data, and Additional Sheets can be exported to Excel
- [x] Image can be exported to PNG, SVG and PDF
- [x] Print works as expected
- [x] Restrict graph to viewport works as expected (check/uncheck)
- [x] Viewport Size Changing works as expected (small/medium/large/fit)
- [x] Toggle between Grid Layout and Force Graph Layout works as expected
- [x] Force Graph Parameter Sliders change the number above them and have an effect on the graph
- [x] Locking/Unlocking/Resetting/Undo Resetting the force graph parameters works as expected
- [x] Enabling and disabling node coloring works as expected
- [x] Node coloring options work as expected (selection top/bottom dataset, averaging values, changing max value)
- [x] Weighted graph loaded with the "Enable Edge Coloring" option checked appears as expected
- [x] Hide/Show Weights works as expected (always/never/upon mouseover)
- [x] Edge Weight Normalization Factor can be changed (set/reset)
- [x] Gray Edge Threshold can be changed, slider changes the number and has an effect on the graph
- [x] Checking Show Gray Edges as Dashed works as expected (check/uncheck)
- [x] D-pad left/right/top/bottom/center works as expected
- [x] Zoom slider changes number and has effect on graph (viewport and menu)
- [ ] Right click on a node opens gene page, page is populated with correct data (currently broken, though)
