### PR TITLE
#1611 

### DIFF
--- a/web-client-classic/public/js/upload.js
+++ b/web-client-classic/public/js/upload.js
@@ -854,9 +854,16 @@ export const upload = function () {
             $("#exportExcelExpressionSource-userInput").html(grnState.name);
             $("#exportExcelWorkbookSheets").html("Select Workbook Sheets to Export:");
             let source = $("input[name=expressionSource]:checked")[0].value;
+            
+            const selectedSheetsBySource = {};
+            
             $("#exportExcelForm").on("change", function () {
                 const selectedValue = $("input[name=expressionSource]:checked")[0].value;
                 if (selectedValue !== source) {
+                    selectedSheetsBySource[source] = [];
+                    $("input[name='workbookSheets']:checked").each(function () { 
+                        selectedSheetsBySource[source].push($(this).vale)
+                    })
                     source = selectedValue;
                     $(".export-excel-workbook-sheet-option-subheader").remove();
                     handleExpressionSheetsFromSource(source);

--- a/web-client-classic/public/js/upload.js
+++ b/web-client-classic/public/js/upload.js
@@ -611,8 +611,16 @@ export const upload = function () {
         return result;
     };
 
-    const createHTMLforSheets = source => {
+    const createHTMLforSheets = (source, savedSheets) => {
         $(".export-excel-workbook-sheet-option").remove();
+
+        const getCheckedAttr = (sheetValue, defaultState = true) => {
+            if (savedSheets) {
+                return savedSheets.includes(sheetValue) ? 'checked="true"' : "";
+            }
+            return defaultState ? 'checked="true"' : "";
+        };
+
         // check if user updated data is selected
         let result = `
             <li class=\'export-excel-workbook-sheet-option export-excel-workbook-sheet-option-subheader\'>
@@ -665,7 +673,7 @@ export const upload = function () {
                 result +
                 `
             <li class=\'export-excel-workbook-sheet-option\'>
-                <input type=\'checkbox\' name=\'workbookSheets\' ${networkOptimizedWeights[0] ? 'checked="true"' : ""} value=\"${networkOptimizedWeights[1]}\" id=\'exportExcelWorkbookSheet-${networkOptimizedWeights[1]}\' class=\'export-checkbox\' ${networkOptimizedWeights[0] ? "" : "disabled"}/>
+                <input type=\'checkbox\' name=\'workbookSheets\' ${getCheckedAttr(networkOptimizedWeights[1], networkOptimizedWeights[0])} value=\"${networkOptimizedWeights[1]}\" id=\'exportExcelWorkbookSheet-${networkOptimizedWeights[1]}\' class=\'export-checkbox\' ${networkOptimizedWeights[0] ? "" : "disabled"}/>
                 <label for=\'exportExcelWorkbookSheet-${networkOptimizedWeights[1]}\' id=\'exportExcelWorkbookSheet-${networkOptimizedWeights[1]}-label\' class=\'export-checkbox-label\' >
                     ${networkOptimizedWeights[1]}
                 </label>
@@ -677,7 +685,7 @@ export const upload = function () {
             result +
             `
             <li class=\'export-excel-workbook-sheet-option\'>
-                <input type=\'checkbox\' name=\'workbookSheets\' checked=\'true\' value=\"${networkWeights[1]}\" id=\'exportExcelWorkbookSheet-${networkWeights[1]}\' class=\'export-checkbox\'/>
+                <input type=\'checkbox\' name=\'workbookSheets\'  ${getCheckedAttr(networkWeights[1])} value=\"${networkWeights[1]}\" id=\'exportExcelWorkbookSheet-${networkWeights[1]}\' class=\'export-checkbox\'/>
                 <label for=\'exportExcelWorkbookSheet-${networkWeights[1]}\' id=\'exportExcelWorkbookSheet-${networkWeights[1]}-label\' class=\'export-checkbox-label\' >
                     ${networkWeights[1]}
                 </label>
@@ -691,7 +699,7 @@ export const upload = function () {
                 for (let expression of grnState.workbook.expressionNames) {
                     result += `
                     <li class=\'export-excel-workbook-sheet-option\'>
-                        <input type=\'checkbox\' name=\'workbookSheets\' checked=\"true\" value=\"${expression}\" id=\'exportExcelWorkbookSheet-${expression}\' class=\'export-checkbox\' />
+                        <input type=\'checkbox\' name=\'workbookSheets\' ${getCheckedAttr(expression)} value=\"${expression}\" id=\'exportExcelWorkbookSheet-${expression}\' class=\'export-checkbox\' />
                         <label for=\'exportExcelWorkbookSheet-${expression}\' id=\'exportExcelWorkbookSheet-${expression}-label\' class=\'export-checkbox-label\' >
                             ${expression}
                         </label>
@@ -702,13 +710,12 @@ export const upload = function () {
             result +=
                 "<p class=\'export-excel-workbook-sheet-option-subheader\'> Additional Sheets </p>";
             for (let sheet of additionalsheets) {
-                result =
-                    result +
-                    `
+                const sheetValue = sheet.slice(sheet.lastIndexOf("_") + 1) + "_log2_expression";
+                result += `
                 <li class=\'export-excel-workbook-sheet-option\'>
-                    <input type=\'checkbox\' name=\'workbookSheets\' checked=\"true\" value=\"${sheet}\" id=\'exportExcelWorkbookSheet-${sheet}\' class=\'export-checkbox\' />
+                    <input type=\'checkbox\' name=\'workbookSheets\' ${getCheckedAttr(sheet)} value=\"${sheet}\" id=\'exportExcelWorkbookSheet-${sheet}\' class=\'export-checkbox\' />
                     <label for=\'exportExcelWorkbookSheet-${sheet}\' id=\'exportExcelWorkbookSheet-${sheet}-label\' class=\'export-checkbox-label\' >
-                        ${sheet}
+                        ${sheetValue}
                     </label>
                 </li>
                 `;
@@ -723,7 +730,7 @@ export const upload = function () {
             for (let sheet of expressionSheets) {
                 result += `
                 <li class=\'export-excel-workbook-sheet-option\'>
-                    <input type=\'checkbox\' name=\'workbookSheets\' checked=\"true\" value=\"${sheet.slice(sheet.lastIndexOf("_") + 1) + "_log2_expression"}\" id=\'exportExcelWorkbookSheet-${sheet}\' class=\'export-checkbox\' />
+                    <input type=\'checkbox\' name=\'workbookSheets\' ${getCheckedAttr(sheet)} value=\"${sheet.slice(sheet.lastIndexOf("_") + 1) + "_log2_expression"}\" id=\'exportExcelWorkbookSheet-${sheet}\' class=\'export-checkbox\' />
                     <label for=\'exportExcelWorkbookSheet-${sheet}\' id=\'exportExcelWorkbookSheet-${sheet}-label\' class=\'export-checkbox-label\' >
                         ${sheet.slice(sheet.lastIndexOf("_") + 1) + "_log2_expression"}
                     </label>
@@ -735,7 +742,7 @@ export const upload = function () {
             for (let sheet of additionalsheets) {
                 result += `
                 <li class=\'export-excel-workbook-sheet-option\'>
-                    <input type=\'checkbox\' name=\'workbookSheets\' checked=\"true\" value=\"${sheet}\" id=\'exportExcelWorkbookSheet-${sheet}\' class=\'export-checkbox\' />
+                    <input type=\'checkbox\' name=\'workbookSheets\' ${getCheckedAttr(sheet)} value=\"${sheet}\" id=\'exportExcelWorkbookSheet-${sheet}\' class=\'export-checkbox\' />
                     <label for=\'exportExcelWorkbookSheet-${sheet}\' id=\'exportExcelWorkbookSheet-${sheet}-label\' class=\'export-checkbox-label\' >
                         ${sheet}
                     </label>
@@ -804,24 +811,37 @@ export const upload = function () {
             .on("click", () => {
                 syncSelectAll();
 
-                let anyExpressionChecked = false;
-                for (let i in allSheets) {
-                    if (
-                        typeof allSheets[i] === "object" &&
-                        allSheets[i].id !== "exportExcelWorkbookSheet-All" &&
-                        allSheets[i].checked &&
-                        allSheets[i].value &&
-                        (allSheets[i].value.includes("expression") ||
-                            allSheets[i].value.includes("sigma"))
-                    ) {
-                        anyExpressionChecked = true;
-                        break;
-                    }
-                }
-                if (!anyExpressionChecked) {
-                    $("#exportExcelExpressionSource-noneRadio").prop("checked", true);
-                }
+                // const anyExpressionChecked = $("input[name=workbookSheets]")
+                //     .not("#exportExcelWorkbookSheet-All")
+                //     .toArray()
+                //     .some(
+                //         el =>
+                //             el.checked &&
+                //             el.value &&
+                //             (el.value.includes("expression") || el.value.includes("sigma"))
+                //     );
+
+                // if (!anyExpressionChecked) {
+                //     $("#exportExcelExpressionSource-noneRadio")
+                //         .prop("checked", true)
+                //         .trigger("change");
+                // }
             });
+
+        //     )
+        // for (let i in allSheets) {
+        //     if (
+        //         typeof allSheets[i] === "object" &&
+        //         allSheets[i].id !== "exportExcelWorkbookSheet-All" &&
+        //         allSheets[i].checked &&
+        //         allSheets[i].value &&
+        //         (allSheets[i].value.includes("expression") ||
+        //             allSheets[i].value.includes("sigma"))
+        //     ) {
+        //         anyExpressionChecked = true;
+        //         break;
+        //     }
+        // }
         $("#exportExcelWorkbookSheet-All").on("click", () => {
             const allSheets = $("input[name=workbookSheets]").not(":disabled");
             const selectAll = $("#exportExcelWorkbookSheet-All");
@@ -834,8 +854,8 @@ export const upload = function () {
         syncSelectAll();
     };
 
-    const handleExpressionSheetsFromSource = function (source) {
-        $("#export-excel-workbook-sheet-list").append(createHTMLforSheets(source));
+    const handleExpressionSheetsFromSource = function (source, savedSheets) {
+        $("#export-excel-workbook-sheet-list").append(createHTMLforSheets(source, savedSheets));
         handleWorkbookSheetCheckboxBehaviour();
         $("#Export-Excel-Button").off("click");
         $("#Export-Excel-Button").on(
@@ -847,35 +867,77 @@ export const upload = function () {
         if (grnState.mode === NETWORK_GRN_MODE) {
             $("#exportExcelForm").remove();
             $("#exportExcelFooter").remove();
-            $("#exportExcelQuestions-containter").append(createHTMLforGRNForm);
+            $("#exportExcelQuestions-containter").append(createHTMLforGRNForm());
             $("#exportExcelFooter-container").append(createHTMLforModalButtons());
             $("#Export-Excel-Button").prop("value", "Export Workbook");
             $("#exportExcelExpressionSources").html("Select the Expression Data Source:");
             $("#exportExcelExpressionSource-userInput").html(grnState.name);
             $("#exportExcelWorkbookSheets").html("Select Workbook Sheets to Export:");
-            let source = $("input[name=expressionSource]:checked")[0].value;
-            
+            let currentRenderedSource = $("input[name=expressionSource]:checked").val();
+
             const selectedSheetsBySource = {};
-            
+
+            const saveCurrentState = () => {
+                if (!currentRenderedSource) return;
+                selectedSheetsBySource[currentRenderedSource] = [];
+                $("input[name='workbookSheets']:checked").each(function () {
+                    selectedSheetsBySource[currentRenderedSource].push($(this).val());
+                });
+            };
+
             $("#exportExcelForm").on("change", function () {
-                const selectedValue = $("input[name=expressionSource]:checked")[0].value;
-                if (selectedValue !== source) {
-                    selectedSheetsBySource[source] = [];
-                    $("input[name='workbookSheets']:checked").each(function () { 
-                        selectedSheetsBySource[source].push($(this).vale)
-                    })
-                    source = selectedValue;
+                saveCurrentState();
+
+                const selectedSource = $("input[name=expressionSource]:checked").val();
+
+                if (selectedSource !== currentRenderedSource) {
+                    currentRenderedSource = selectedSource;
+
                     $(".export-excel-workbook-sheet-option-subheader").remove();
-                    handleExpressionSheetsFromSource(source);
+
+                    handleExpressionSheetsFromSource(
+                        currentRenderedSource,
+                        selectedSheetsBySource[currentRenderedSource]
+                    );
                 }
             });
-            handleExpressionSheetsFromSource(source);
+            handleExpressionSheetsFromSource(
+                currentRenderedSource,
+                selectedSheetsBySource[currentRenderedSource]
+            );
+
+            // selectedSheetsBySource[source] = [];
+            // $("input[name='workbookSheets']:checked").each(function () {
+            //     selectedSheetsBySource[source].push($(this).val());
+            // });
+
+            // source = selectedValue;
+            // $(".export-excel-workbook-sheet-option-subheader").remove();
+            // handleExpressionSheetsFromSource(source);
+
+            // if (selectedSheetsBySource[source]) {
+            //     $("inpute[name='workbookSheets']").prop("checked", false);
+
+            //     selectedSheetsBySource[source].forEach(val => {
+            //         $("inpute[name='workbookSheets']")
+            //             .filter(function () {
+            //                 return $(this).vale() == val;
+            //             })
+            //             .prop("checked", true);
+            //     });
+            //     const allSheets = $("input[name=workbookSheets]")
+            //         .not("#exportExcelWorkbookSheet-All")
+            //         .not(":disabled");
+            //     const allChecked =
+            //         allSheets.length > 0 && allSheets.toArray().every(el => el.checked);
+            //     $("#exportExcelWorkbookSheet-All").prop("checked", allChecked);
+            // }
         } else if (grnState.mode === NETWORK_PPI_MODE) {
             const source = "userInput";
             $("#exportExcelForm").remove();
             $("#exportExcelFooter").remove();
             $("#exportExcelQuestions-containter").append(
-                createHTMLforProteinProteinPhysicalInteractionForm
+                createHTMLforProteinProteinPhysicalInteractionForm()
             );
             $("#exportExcelFooter-container").append(createHTMLforModalButtons());
             $("#Export-Excel-Button").prop("value", "Export Workbook");

--- a/web-client-classic/public/js/upload.js
+++ b/web-client-classic/public/js/upload.js
@@ -520,6 +520,13 @@ export const upload = function () {
     const createHTMLforSheets = (source, savedSheets) => {
         $(".export-excel-workbook-sheet-option").remove();
 
+        const getCheckedAttr = (sheetValue, defaultState = true) => {
+            if (savedSheets) {
+                return savedSheets.includes(sheetValue) ? 'checked="true"' : "";
+            }
+            return defaultState ? 'checked="true"' : "";
+        };
+
         const sources = [
             ...new Set(
                 grnState.database.expressionDatasets.map(s => s.slice(0, s.lastIndexOf("_")))
@@ -570,8 +577,8 @@ export const upload = function () {
         if (networkOptimizedWeights[0]) {
             result += `
             <li class=\'export-excel-workbook-sheet-option\'>
-                <input type=\'checkbox\' name=\'workbookSheets\' checked="true" value=\"${networkOptimizedWeights[1]}\" id=\'exportExcelWorkbookSheet-${networkOptimizedWeights[1]}\' class=\'export-checkbox\'/>
-                <label for=\'exportExcelWorkbookSheet-${networkOptimizedWeights[1]}\' class=\'export-checkbox-label\'>${networkOptimizedWeights[1]}</label>
+                <input type="checkbox" name="workbookSheets" ${getCheckedAttr(networkOptimizedWeights[1])} value="${networkOptimizedWeights[1]}" id="exportExcelWorkbookSheet-${networkOptimizedWeights[1]}" class="export-checkbox"/>
+                <label for="exportExcelWorkbookSheet-${networkOptimizedWeights[1]}" class="export-checkbox-label">${networkOptimizedWeights[1]}</label>
             </li>
         `;
         }
@@ -579,8 +586,8 @@ export const upload = function () {
         let networkWeights = networks[2];
         result += `
         <li class=\'export-excel-workbook-sheet-option\'>
-            <input type=\'checkbox\' name=\'workbookSheets\' checked=\'true\' value=\"${networkWeights[1]}\" id=\'exportExcelWorkbookSheet-${networkWeights[1]}\' class=\'export-checkbox\'/>
-            <label for=\'exportExcelWorkbookSheet-${networkWeights[1]}\' class=\'export-checkbox-label\'>${networkWeights[1]}</label>
+            <input type="checkbox" name="workbookSheets" ${getCheckedAttr(networkWeights[1])} value="${networkWeights[1]}" id="exportExcelWorkbookSheet-${networkWeights[1]}" class="export-checkbox"/>
+            <label for="exportExcelWorkbookSheet-${networkWeights[1]}" class="export-checkbox-label">${networkWeights[1]}</label>
         </li>
     `;
 
@@ -606,35 +613,36 @@ export const upload = function () {
         if (source === "userInput" && grnState.workbook.expressionNames) {
             for (let expression of grnState.workbook.expressionNames) {
                 result += `
-            <li class=\'export-excel-workbook-sheet-option\'>
-                <input type=\'checkbox\' name=\'workbookSheets\' checked=\"true\" value=\"${expression}\" id=\'exportExcelWorkbookSheet-${expression}\' class=\'export-checkbox\' />
-                <label for=\'exportExcelWorkbookSheet-${expression}\' class=\'export-checkbox-label\'>${expression}</label>
-            </li>
-            `;
+        <li class="export-excel-workbook-sheet-option">
+            <input type="checkbox" name="workbookSheets" ${getCheckedAttr(expression)} value="${expression}" id="exportExcelWorkbookSheet-${expression}" class="export-checkbox" />
+            <label for="exportExcelWorkbookSheet-${expression}" class="export-checkbox-label">${expression}</label>
+        </li>
+        `;
             }
         } else if (source !== "none") {
             const expressionSheets = grnState.database.expressionDatasets.filter(s =>
                 s.includes(source)
             );
             for (let sheet of expressionSheets) {
+                const sheetValue = sheet.slice(sheet.lastIndexOf("_") + 1) + "_log2_expression";
                 result += `
-            <li class=\'export-excel-workbook-sheet-option\'>
-                <input type=\'checkbox\' name=\'workbookSheets\' checked=\"true\" value=\"${sheet.slice(sheet.lastIndexOf("_") + 1) + "_log2_expression"}\" id=\'exportExcelWorkbookSheet-${sheet}\' class=\'export-checkbox\' />
-                <label for=\'exportExcelWorkbookSheet-${sheet}\' class=\'export-checkbox-label\'>${sheet.slice(sheet.lastIndexOf("_") + 1) + "_log2_expression"}</label>
-            </li>`;
+        <li class="export-excel-workbook-sheet-option">
+            <input type="checkbox" name="workbookSheets" ${getCheckedAttr(sheetValue)} value="${sheetValue}" id="exportExcelWorkbookSheet-${sheet}" class="export-checkbox" />
+            <label for="exportExcelWorkbookSheet-${sheet}" class="export-checkbox-label">${sheetValue}</label>
+        </li>`;
             }
             result += `
-            <div class=\'expression-db-loader\'></div>
-            <div class=\'expression-db-loader-text\'>Expression Database is Loading</div>
+            <div class="expression-db-loader"></div>
+            <div class="expression-db-loader-text">Expression Database is Loading</div>
         `;
         }
 
         result += `<p class=\'export-excel-workbook-sheet-option-subheader\'> Additional Sheets </p>`;
         for (let sheet of additionalsheets) {
             result += `
-        <li class=\'export-excel-workbook-sheet-option\'>
-            <input type=\'checkbox\' name=\'workbookSheets\' checked=\"true\" value=\"${sheet}\" id=\'exportExcelWorkbookSheet-${sheet}\' class=\'export-checkbox\' />
-            <label for=\'exportExcelWorkbookSheet-${sheet}\' class=\'export-checkbox-label\'>${sheet}</label>
+        <li class="export-excel-workbook-sheet-option">
+            <input type="checkbox" name="workbookSheets" ${getCheckedAttr(sheet)} value="${sheet}" id="exportExcelWorkbookSheet-${sheet}" class="export-checkbox" />
+            <label for="exportExcelWorkbookSheet-${sheet}" class="export-checkbox-label">${sheet}</label>
         </li>
         `;
         }
@@ -750,6 +758,15 @@ export const upload = function () {
                 source = "userInput";
             }
 
+            const selectedSheetsBySource = {};
+
+            const saveCurrentState = () => {
+                selectedSheetsBySource[source] = [];
+                $("input[name='workbookSheets']:checked").each(function () {
+                    selectedSheetsBySource[source].push($(this).val());
+                });
+            };
+
             handleExpressionSheetsFromSource(source);
 
             $("#export-excel-workbook-sheet-list").off("change", "#expressionSourceDropdown");
@@ -759,9 +776,10 @@ export const upload = function () {
                 function () {
                     const selectedValue = $(this).val();
                     if (selectedValue !== source) {
+                        saveCurrentState();
                         source = selectedValue;
                         $(".export-excel-workbook-sheet-option-subheader").remove();
-                        handleExpressionSheetsFromSource(source);
+                        handleExpressionSheetsFromSource(source, selectedSheetsBySource[source]);
                     }
                 }
             );


### PR DESCRIPTION

Pull Request Checklist
- [x] GitHub Actions C.I. build passes
- [x] All five Demos look as expected when loaded
- [x] Reload works as expected
- [x] Load an Excel file (GRN and PPI)
- [x] Load a SIF file (GRN and PPI)
- [x] Load a GraphML file (GRN)
- [x] Loading file with Error brings up error modal, and it looks as expected
- [x] Loading file with Warning brings up warnings modal
- [x] Loading a network from the database looks as expected when loaded (GRN and PPI)
- [x] Network can be exported to SIF (GRN and PPI) and GraphML (GRN-only)
- [x] Network, Expression data, and Additional Sheets can be exported to Excel
- [x] Image can be exported to PNG, SVG and PDF
- [x] Print works as expected
- [x] Restrict graph to viewport works as expected (check/uncheck)
- [x] Viewport Size Changing works as expected (small/medium/large/fit)
- [x] Toggle between Grid Layout and Force Graph Layout works as expected
- [x] Force Graph Parameter Sliders change the number above them and have an effect on the graph
- [x] Locking/Unlocking/Resetting/Undo Resetting the force graph parameters works as expected
- [x] Enabling and disabling node coloring works as expected
- [x] Node coloring options work as expected (selection top/bottom dataset, averaging values, changing max value)
- [x] Weighted graph loaded with the "Enable Edge Coloring" option checked appears as expected
- [x] Hide/Show Weights works as expected (always/never/upon mouseover)
- [x] Edge Weight Normalization Factor can be changed (set/reset)
- [x] Gray Edge Threshold can be changed, slider changes the number and has an effect on the graph
- [x] Checking Show Gray Edges as Dashed works as expected (check/uncheck)
- [x] D-pad left/right/top/bottom/center works as expected
- [x] Zoom slider changes number and has effect on graph (viewport and menu)
- [ ] Right click on a node opens gene page, page is populated with correct data (currently broken, though)
