### PR TITLE
#1357 Node coloring menu mimics edge menu

### DIFF
--- a/web-client-classic/public/js/update-app.js
+++ b/web-client-classic/public/js/update-app.js
@@ -1092,12 +1092,6 @@ export const updateApp = grnState => {
         updaters.renderNodeColoring();
     }
 
-    // if (grnState.nodeColoring.showMenu) {
-    //     showNodeColoringMenus();
-    // } else {
-    //     disableNodeColoringMenus();
-    // }
-
     updateLogFoldChangeMaxValue();
     updateTopDataset();
     updateBottomDataset();

--- a/web-client-classic/public/js/update-app.js
+++ b/web-client-classic/public/js/update-app.js
@@ -922,6 +922,13 @@ export const updateApp = grnState => {
         hasExpressionData(grnState.workbook.expression)
     ) {
         grnState.nodeColoring.showMenu = true;
+        $(NODE_COLORING_SIDEBAR_BODY).removeClass("hidden");
+        $(NODE_COLORING_SIDEBAR_BODY).find("input, select, button").prop("disabled", false);
+        $(NODE_COLORING_NAVBAR_OPTIONS).removeClass("disabled");
+        $(NODE_COLORING_NAVBAR_OPTIONS).find("li").removeClass("disabled");
+        $("#node-coloring-toggle-menu").parent().removeClass("disabled");
+        $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).prop("disabled", false);
+
         $(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked", true);
         $(`${NODE_COLORING_TOGGLE_MENU} span`).addClass("glyphicon-ok");
         $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).val(DEFAULT_MAX_LOG_FOLD_CHANGE);
@@ -966,6 +973,14 @@ export const updateApp = grnState => {
         }
 
         grnState.nodeColoring.showMenu = true;
+
+        $(NODE_COLORING_SIDEBAR_BODY).removeClass("hidden");
+        $(NODE_COLORING_SIDEBAR_BODY).find("input, select, button").prop("disabled", false);
+        $(NODE_COLORING_NAVBAR_OPTIONS).removeClass("disabled");
+        $(NODE_COLORING_NAVBAR_OPTIONS).find("li").removeClass("disabled");
+        $("#node-coloring-toggle-menu").parent().removeClass("disabled");
+        $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).prop("disabled", false);
+
         grnState.nodeColoring.topDataset = grnState.nodeColoring.topDataset
             ? grnState.nodeColoring.topDataset
             : "Dahlquist_2018_wt";
@@ -984,6 +999,8 @@ export const updateApp = grnState => {
             grnState.nodeColoring.averageBottomDataset
         );
 
+        enableNodeColoringUI();
+
         if (grnState.workbook.expression[grnState.nodeColoring.topDataset] === undefined) {
             loadExpressionDatabase(true);
         } else if (
@@ -992,7 +1009,6 @@ export const updateApp = grnState => {
         ) {
             loadExpressionDatabase(false);
         } else {
-            enableNodeColoringUI();
             // There is as problem here! When a dataset from the database is used to do node coloring,
             // but then the layout of the graph is changed (force graph to grid layout, for instance),
             // node coloring goes away, seemingly inexplicably.

--- a/web-client-classic/public/js/update-app.js
+++ b/web-client-classic/public/js/update-app.js
@@ -124,6 +124,9 @@ import { queryExpressionDatabase } from "./api/grnsight-api.js";
 queryExpressionDatabase({ type: "ExpressionDatasets" })
     .then(function (response) {
         grnState.database = response;
+        if (grnState.workbook) {
+            resetDatasetDropdownMenus(grnState.workbook);
+        }
     })
     .catch(function (error) {
         console.log(error.stack);
@@ -717,7 +720,7 @@ const resetDatasetDropdownMenus = workbook => {
     }
 
     // Add expression database options
-    grnState.database.expressionDatasets.forEach(option =>
+    (grnState.database.expressionDatasets || []).forEach(option =>
         grnState.nodeColoring.nodeColoringOptions.databaseExpressions.push({
             value: [option],
         })
@@ -843,9 +846,9 @@ export const updateApp = grnState => {
         // made a choice and we will let the choice stick.
         if (hasExpressionData(grnState.workbook.expression)) {
             resetDatasetDropdownMenus(grnState.workbook);
-            if (grnState.nodeColoring.nodeColoringEnabled === undefined) {
-                grnState.nodeColoring.nodeColoringEnabled = true;
-            }
+            // if (grnState.nodeColoring.nodeColoringEnabled === undefined) {
+            //     grnState.nodeColoring.nodeColoringEnabled = false;
+            // }
 
             if (isNewWorkbook(name)) {
                 grnState.nodeColoring.showMenu = true;
@@ -930,28 +933,35 @@ export const updateApp = grnState => {
     ) {
         grnState.nodeColoring.showMenu = true;
         $(NODE_COLORING_SIDEBAR_BODY).find("input,select, button").prop("disabled", false);
+        $(LOG_FOLD_CHANGE_MAX_VALUE_MENU).prop("disabled", false);
         $(AVG_REPLICATE_VALS_TOP_SIDEBAR).prop("checked", true);
+        $(NODE_COLORING_NAVBAR_OPTIONS).find("li").removeClass("disabled");
         $(AVG_REPLICATE_VALS_TOP_SIDEBAR).prop("checked", true);
         $(AVG_REPLICATE_VALS_BOTTOM_SIDEBAR).prop("checked", true);
         $(`${NODE_COLORING_TOGGLE_MENU} span`).addClass("glyphicon-ok");
         $(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked", true);
         $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).val(DEFAULT_MAX_LOG_FOLD_CHANGE);
         $(NODE_COLORING_SIDEBAR_BODY).removeClass("hidden");
-        $(NODE_COLORING_MENU).removeClass("hidden");
-        $(NODE_COLORING_NAVBAR_OPTIONS).removeClass("hidden");
+        $(NODE_COLORING_MENU).removeClass("disabled");
+        $(NODE_COLORING_NAVBAR_OPTIONS).removeClass("disabled");
+        $(".node-coloring-menu").removeClass("disabled");
         if (grnState.mode === NETWORK_PPI_MODE) {
             displayPPINodeColorWarning(grnState.ppiNodeColorWarningDisplayed);
             grnState.ppiNodeColorWarningDisplayed = true;
         }
         if (
-            grnState.database.expressionDatasets.includes(grnState.nodeColoring.topDataset) &&
+            (grnState.database.expressionDatasets || []).includes(
+                grnState.nodeColoring.topDataset
+            ) &&
             grnState.workbook.expression[grnState.nodeColoring.topDataset] === undefined
         ) {
             if ($(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked")) {
                 loadExpressionDatabase(true);
             }
         } else if (
-            grnState.database.expressionDatasets.includes(grnState.nodeColoring.bottomDataset) &&
+            (grnState.database.expressionDataset || []).includes(
+                grnState.nodeColoring.bottomDataset
+            ) &&
             !grnState.nodeColoring.bottomDataSameAsTop &&
             grnState.workbook.expression[grnState.nodeColoring.bottomDataset] === undefined
         ) {
@@ -971,25 +981,28 @@ export const updateApp = grnState => {
             (!grnState.nodeColoring.bottomDataSameAsTop &&
                 grnState.workbook.expression[grnState.nodeColoring.bottomDataset] === undefined)
         ) {
-            updaters.removeNodeColoring();
+            // updaters.removeNodeColoring();
             resetDatasetDropdownMenus(grnState.workbook);
         }
-        grnState.nodeColoring.showMenu = true;
+        grnState.nodeColoring.showMenu = false;
         grnState.nodeColoring.topDataset = grnState.nodeColoring.topDataset
             ? grnState.nodeColoring.topDataset
             : "Dahlquist_2018_wt";
         grnState.nodeColoring.bottomDataset = grnState.nodeColoring.bottomDataset
             ? grnState.nodeColoring.bottomDataset
             : "Dahlquist_2018_wt";
-        $(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked", true);
-        $(`${NODE_COLORING_TOGGLE_MENU} span`).addClass("glyphicon-ok");
-        $(NODE_COLORING_SIDEBAR_BODY).removeClass("hidden");
-        $(NODE_COLORING_MENU).removeClass("hidden");
-        $(NODE_COLORING_NAVBAR_OPTIONS).removeClass("hidden");
+        $(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked", false);
+        $(`${NODE_COLORING_TOGGLE_MENU} span`).removeClass("glyphicon-ok");
+        $(NODE_COLORING_SIDEBAR_BODY).find("input, select, button").prop("disabled", true);
+        $(NODE_COLORING_NAVBAR_OPTIONS).addClass("disabled");
+        $(".node-coloring-menu").addClass("disabled");
+        $(NODE_COLORING_TOGGLE_MENU).removeClass("disabled");
+        $(NODE_COLORING_TOGGLE_MENU).closest("li").removeClass("disabled");
+
+        $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).prop("disabled", true);
         $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).val(DEFAULT_MAX_LOG_FOLD_CHANGE);
         $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).addClass("hidden");
         $(NODE_COLORING_SIDEBAR_BODY).find("input, select, button").prop("disabled", false);
-        $(NODE_COLORING_MENU).removeClass("hidden");
         $(TOP_DATASET_SELECTION_SIDEBAR).val(grnState.nodeColoring.topDataset);
         $(BOTTOM_DATASET_SELECTION_SIDEBAR).val(grnState.nodeColoring.bottomDataset);
         $(AVG_REPLICATE_VALS_TOP_SIDEBAR).prop("checked", grnState.nodeColoring.averageTopDataset);
@@ -1047,7 +1060,11 @@ export const updateApp = grnState => {
             grnState.nodeColoring.averageBottomDataset
         );
         $(NODE_COLORING_MENU).addClass("disabled");
-        $(NODE_COLORING_NAVBAR_OPTIONS).addClass("hidden");
+        $(NODE_COLORING_NAVBAR_OPTIONS).addClass("disabled");
+        $(NODE_COLORING_NAVBAR_OPTIONS).find("li").addClass("disabled");
+        $(NODE_COLORING_TOGGLE_MENU).removeClass("disabled");
+        $(NODE_COLORING_TOGGLE_MENU).closest("li").removeClass("disabled");
+        $(LOG_FOLD_CHANGE_MAX_VALUE_MENU).prop("disabled", true);
         $(`${NODE_COLORING_TOGGLE_MENU} span`).removeClass("glyphicon-ok");
         $(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked", false);
         if (grnState.mode === NETWORK_PPI_MODE) {

--- a/web-client-classic/public/js/update-app.js
+++ b/web-client-classic/public/js/update-app.js
@@ -942,7 +942,7 @@ export const updateApp = grnState => {
             displayPPINodeColorWarning(grnState.ppiNodeColorWarningDisplayed);
             grnState.ppiNodeColorWarningDisplayed = true;
         }
-        
+
         if (
             (grnState.database.expressionDatasets || []).includes(
                 grnState.nodeColoring.topDataset

--- a/web-client-classic/public/js/update-app.js
+++ b/web-client-classic/public/js/update-app.js
@@ -932,42 +932,32 @@ export const updateApp = grnState => {
         hasExpressionData(grnState.workbook.expression)
     ) {
         grnState.nodeColoring.showMenu = true;
-        $(NODE_COLORING_SIDEBAR_BODY).find("input,select, button").prop("disabled", false);
-        $(LOG_FOLD_CHANGE_MAX_VALUE_MENU).prop("disabled", false);
-        $(AVG_REPLICATE_VALS_TOP_SIDEBAR).prop("checked", true);
-        $(NODE_COLORING_NAVBAR_OPTIONS).find("li").removeClass("disabled");
+        $(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked", true);
+        $(`${NODE_COLORING_TOGGLE_MENU} span`).addClass("glyphicon-ok");
+        $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).val(DEFAULT_MAX_LOG_FOLD_CHANGE);
         $(AVG_REPLICATE_VALS_TOP_SIDEBAR).prop("checked", true);
         $(AVG_REPLICATE_VALS_BOTTOM_SIDEBAR).prop("checked", true);
-        $(`${NODE_COLORING_TOGGLE_MENU} span`).addClass("glyphicon-ok");
-        $(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked", true);
-        $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).val(DEFAULT_MAX_LOG_FOLD_CHANGE);
-        $(NODE_COLORING_SIDEBAR_BODY).removeClass("hidden");
-        $(NODE_COLORING_MENU).removeClass("disabled");
-        $(NODE_COLORING_NAVBAR_OPTIONS).removeClass("disabled");
-        $(".node-coloring-menu").removeClass("disabled");
+
         if (grnState.mode === NETWORK_PPI_MODE) {
             displayPPINodeColorWarning(grnState.ppiNodeColorWarningDisplayed);
             grnState.ppiNodeColorWarningDisplayed = true;
         }
+        
         if (
             (grnState.database.expressionDatasets || []).includes(
                 grnState.nodeColoring.topDataset
             ) &&
             grnState.workbook.expression[grnState.nodeColoring.topDataset] === undefined
         ) {
-            if ($(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked")) {
-                loadExpressionDatabase(true);
-            }
+            loadExpressionDatabase(true);
         } else if (
-            (grnState.database.expressionDataset || []).includes(
+            (grnState.database.expressionDatasets || []).includes(
                 grnState.nodeColoring.bottomDataset
             ) &&
             !grnState.nodeColoring.bottomDataSameAsTop &&
             grnState.workbook.expression[grnState.nodeColoring.bottomDataset] === undefined
         ) {
-            if (!grnState.nodeColoring.bottomDataSameAsTop) {
-                loadExpressionDatabase(false);
-            }
+            loadExpressionDatabase(false);
         } else {
             updaters.renderNodeColoring();
         }
@@ -981,28 +971,17 @@ export const updateApp = grnState => {
             (!grnState.nodeColoring.bottomDataSameAsTop &&
                 grnState.workbook.expression[grnState.nodeColoring.bottomDataset] === undefined)
         ) {
-            // updaters.removeNodeColoring();
             resetDatasetDropdownMenus(grnState.workbook);
         }
-        grnState.nodeColoring.showMenu = false;
-        grnState.nodeColoring.topDataset = grnState.nodeColoring.topDataset
-            ? grnState.nodeColoring.topDataset
-            : "Dahlquist_2018_wt";
-        grnState.nodeColoring.bottomDataset = grnState.nodeColoring.bottomDataset
-            ? grnState.nodeColoring.bottomDataset
-            : "Dahlquist_2018_wt";
-        $(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked", false);
-        $(`${NODE_COLORING_TOGGLE_MENU} span`).removeClass("glyphicon-ok");
-        $(NODE_COLORING_SIDEBAR_BODY).find("input, select, button").prop("disabled", true);
-        $(NODE_COLORING_NAVBAR_OPTIONS).addClass("disabled");
-        $(".node-coloring-menu").addClass("disabled");
-        $(NODE_COLORING_TOGGLE_MENU).removeClass("disabled");
-        $(NODE_COLORING_TOGGLE_MENU).closest("li").removeClass("disabled");
 
-        $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).prop("disabled", true);
+        grnState.nodeColoring.showMenu = true;
+        grnState.nodeColoring.topDataset = grnState.nodeColoring.topDataset || "Dahlquist_2018_wt";
+        grnState.nodeColoring.bottomDataset =
+            grnState.nodeColoring.bottomDataset || "Dahlquist_2018_wt";
+
+        $(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked", true);
+        $(`${NODE_COLORING_TOGGLE_MENU} span`).addClass("glyphicon-ok");
         $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).val(DEFAULT_MAX_LOG_FOLD_CHANGE);
-        $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).addClass("hidden");
-        $(NODE_COLORING_SIDEBAR_BODY).find("input, select, button").prop("disabled", false);
         $(TOP_DATASET_SELECTION_SIDEBAR).val(grnState.nodeColoring.topDataset);
         $(BOTTOM_DATASET_SELECTION_SIDEBAR).val(grnState.nodeColoring.bottomDataset);
         $(AVG_REPLICATE_VALS_TOP_SIDEBAR).prop("checked", grnState.nodeColoring.averageTopDataset);
@@ -1010,48 +989,41 @@ export const updateApp = grnState => {
             "checked",
             grnState.nodeColoring.averageBottomDataset
         );
-        $(LOG_FOLD_CHANGE_MAX_VALUE_SIDEBAR_BUTTON).addClass("hidden");
-        $(LOG_FOLD_CHANGE_MAX_VALUE_HEADER).addClass("hidden");
-        if ($(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked")) {
-            if (grnState.workbook.expression[grnState.nodeColoring.topDataset] === undefined) {
-                loadExpressionDatabase(true);
-            } else if (
-                !grnState.nodeColoring.bottomDataSameAsTop &&
-                grnState.workbook.expression[grnState.nodeColoring.bottomDataset] === undefined
-            ) {
-                loadExpressionDatabase(false);
-            } else {
-                enableNodeColoringUI();
-                // There is as problem here! When a dataset from the database is used to do node coloring,
-                // but then the layout of the graph is changed (force graph to grid layout, for instance),
-                // node coloring goes away, seemingly inexplicably.
-                // !!!!! TEMPORARY WORKAROUND:
-                //   Calling `updaters.renderNodeColoring()` inline does not succeed; instead, a delay
-                //   has to take place, done here via `setTimeout`.
-                //
-                //   The delay is built-in to the cases where a query has to happen first.
-                //
-                //   For some reason, calling updates.renderNodeColoring() _synchronously_ does not
-                //   actually perform the node coloring.
-                //
-                //   Investigate why a timeout is required in order for node coloring to take place
-                //   successfully in this case.
-                setTimeout(() => updaters.renderNodeColoring(), 250);
-            }
-            if (grnState.mode === NETWORK_PPI_MODE) {
-                displayPPINodeColorWarning(grnState.ppiNodeColorWarningDisplayed);
-                grnState.ppiNodeColorWarningDisplayed = true;
-            }
+
+        if (grnState.workbook.expression[grnState.nodeColoring.topDataset] === undefined) {
+            loadExpressionDatabase(true);
+        } else if (
+            !grnState.nodeColoring.bottomDataSameAsTop &&
+            grnState.workbook.expression[grnState.nodeColoring.bottomDataset] === undefined
+        ) {
+            loadExpressionDatabase(false);
+        } else {
+            enableNodeColoringUI();
+            // There is as problem here! When a dataset from the database is used to do node coloring,
+            // but then the layout of the graph is changed (force graph to grid layout, for instance),
+            // node coloring goes away, seemingly inexplicably.
+            // !!!!! TEMPORARY WORKAROUND:
+            //   Calling `updaters.renderNodeColoring()` inline does not succeed; instead, a delay
+            //   has to take place, done here via `setTimeout`.
+            //
+            //   The delay is built-in to the cases where a query has to happen first.
+            //
+            //   For some reason, calling updates.renderNodeColoring() _synchronously_ does not
+            //   actually perform the node coloring.
+            //
+            //   Investigate why a timeout is required in order for node coloring to take place
+            //   successfully in this case.
+            setTimeout(() => updaters.renderNodeColoring(), 250);
+        }
+
+        if (grnState.mode === NETWORK_PPI_MODE) {
+            displayPPINodeColorWarning(grnState.ppiNodeColorWarningDisplayed);
+            grnState.ppiNodeColorWarningDisplayed = true;
         }
     } else if (grnState.workbook !== null && !grnState.nodeColoring.nodeColoringEnabled) {
         grnState.nodeColoring.showMenu = true;
-        // $(NODE_COLORING_SIDEBAR_BODY).addClass("hidden");
-        $(NODE_COLORING_SIDEBAR_BODY).removeClass("hidden");
-        $(NODE_COLORING_SIDEBAR_BODY).find("input, select, button").prop("disabled", true);
-        // $(`${NODE_COLORING_SIDEBAR_BODY} input, ${NODE_COLORING_SIDEBAR_BODY} button`).prop(
-        //     "disabled",
-        //     true
-        // );
+        $(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked", false);
+        $(`${NODE_COLORING_TOGGLE_MENU} span`).removeClass("glyphicon-ok");
         $(TOP_DATASET_SELECTION_SIDEBAR).val(grnState.nodeColoring.topDataset);
         $(BOTTOM_DATASET_SELECTION_SIDEBAR).val(grnState.nodeColoring.bottomDataset);
         $(AVG_REPLICATE_VALS_TOP_SIDEBAR).prop("checked", grnState.nodeColoring.averageTopDataset);
@@ -1059,18 +1031,23 @@ export const updateApp = grnState => {
             "checked",
             grnState.nodeColoring.averageBottomDataset
         );
-        $(NODE_COLORING_MENU).addClass("disabled");
-        $(NODE_COLORING_NAVBAR_OPTIONS).addClass("disabled");
-        $(NODE_COLORING_NAVBAR_OPTIONS).find("li").addClass("disabled");
-        $(NODE_COLORING_TOGGLE_MENU).removeClass("disabled");
-        $(NODE_COLORING_TOGGLE_MENU).closest("li").removeClass("disabled");
-        $(LOG_FOLD_CHANGE_MAX_VALUE_MENU).prop("disabled", true);
-        $(`${NODE_COLORING_TOGGLE_MENU} span`).removeClass("glyphicon-ok");
-        $(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked", false);
+
         if (grnState.mode === NETWORK_PPI_MODE) {
             grnState.ppiNodeColorWarningDisplayed = false;
         }
     }
+
+    const nodeColoringOff = !grnState.nodeColoring.nodeColoringEnabled;
+    $(NODE_COLORING_SIDEBAR_BODY).find("input, select, button").prop("disabled", nodeColoringOff);
+    $(NODE_COLORING_SIDEBAR_BODY).toggleClass("disabled", nodeColoringOff);
+    $(LOG_FOLD_CHANGE_MAX_VALUE_MENU).prop("disabled", nodeColoringOff);
+    $(TOP_DATASET_SELECTION_SIDEBAR).prop("disabled", nodeColoringOff);
+    $(BOTTOM_DATASET_SELECTION_SIDEBAR).prop("disabled", nodeColoringOff);
+    $(AVG_REPLICATE_VALS_TOP_SIDEBAR).prop("disabled", nodeColoringOff);
+    $(AVG_REPLICATE_VALS_BOTTOM_SIDEBAR).prop("disabled", nodeColoringOff);
+    $(".node-coloring-navbar-options").toggleClass("disabled", nodeColoringOff);
+    $(".node-coloring-menu").toggleClass("disabled", nodeColoringOff);
+    $(NODE_COLORING_TOGGLE_MENU).closest("li").removeClass("disabled");
 
     if (grnState.workbook !== null && grnState.workbook.sheetType === "weighted") {
         showEdgeWeightOptions();
@@ -1115,11 +1092,11 @@ export const updateApp = grnState => {
         updaters.renderNodeColoring();
     }
 
-    if (grnState.nodeColoring.showMenu) {
-        showNodeColoringMenus();
-    } else {
-        disableNodeColoringMenus();
-    }
+    // if (grnState.nodeColoring.showMenu) {
+    //     showNodeColoringMenus();
+    // } else {
+    //     disableNodeColoringMenus();
+    // }
 
     updateLogFoldChangeMaxValue();
     updateTopDataset();

--- a/web-client-classic/public/js/update-app.js
+++ b/web-client-classic/public/js/update-app.js
@@ -524,7 +524,6 @@ const updatetoGridLayout = () => {};
 // Node Coloring Functions
 const showNodeColoringMenus = () => {
     $(NODE_COLORING_SIDEBAR_PANEL).removeClass("disabled");
-    $(NODE_COLORING_SIDEBAR_PANEL).addClass("in");
     $(NODE_COLORING_MENU).removeClass("disabled");
     $(NODE_COLORING_MENU_CLASS).removeClass("disabled");
     $(NODE_COLORING_SIDEBAR_HEADER_LINK).attr("data-toggle", "collapse");
@@ -532,7 +531,6 @@ const showNodeColoringMenus = () => {
 
 const disableNodeColoringMenus = () => {
     $(NODE_COLORING_SIDEBAR_PANEL).addClass("disabled");
-    $(NODE_COLORING_SIDEBAR_PANEL).removeClass("in");
     $(NODE_COLORING_MENU_CLASS).addClass("disabled");
     $(NODE_COLORING_MENU).addClass("disabled");
     $(NODE_COLORING_SIDEBAR_HEADER_LINK).attr("data-toggle", "");
@@ -931,6 +929,8 @@ export const updateApp = grnState => {
         hasExpressionData(grnState.workbook.expression)
     ) {
         grnState.nodeColoring.showMenu = true;
+        $(NODE_COLORING_SIDEBAR_BODY).find("input,select, button").prop("disabled", false);
+        $(AVG_REPLICATE_VALS_TOP_SIDEBAR).prop("checked", true);
         $(AVG_REPLICATE_VALS_TOP_SIDEBAR).prop("checked", true);
         $(AVG_REPLICATE_VALS_BOTTOM_SIDEBAR).prop("checked", true);
         $(`${NODE_COLORING_TOGGLE_MENU} span`).addClass("glyphicon-ok");
@@ -988,7 +988,7 @@ export const updateApp = grnState => {
         $(NODE_COLORING_NAVBAR_OPTIONS).removeClass("hidden");
         $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).val(DEFAULT_MAX_LOG_FOLD_CHANGE);
         $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).addClass("hidden");
-        $(NODE_COLORING_SIDEBAR_BODY).find("input, select, button").prop("disabled, false");
+        $(NODE_COLORING_SIDEBAR_BODY).find("input, select, button").prop("disabled", false);
         $(NODE_COLORING_MENU).removeClass("hidden");
         $(TOP_DATASET_SELECTION_SIDEBAR).val(grnState.nodeColoring.topDataset);
         $(BOTTOM_DATASET_SELECTION_SIDEBAR).val(grnState.nodeColoring.bottomDataset);

--- a/web-client-classic/public/js/update-app.js
+++ b/web-client-classic/public/js/update-app.js
@@ -532,13 +532,6 @@ const showNodeColoringMenus = () => {
     $(NODE_COLORING_SIDEBAR_HEADER_LINK).attr("data-toggle", "collapse");
 };
 
-const disableNodeColoringMenus = () => {
-    $(NODE_COLORING_SIDEBAR_PANEL).addClass("disabled");
-    $(NODE_COLORING_MENU_CLASS).addClass("disabled");
-    $(NODE_COLORING_MENU).addClass("disabled");
-    $(NODE_COLORING_SIDEBAR_HEADER_LINK).attr("data-toggle", "");
-};
-
 const isNewWorkbook = name => {
     return grnState.nodeColoring.lastDataset === null || grnState.nodeColoring.lastDataset !== name;
 };

--- a/web-client-classic/public/js/update-app.js
+++ b/web-client-classic/public/js/update-app.js
@@ -988,6 +988,15 @@ export const updateApp = grnState => {
         $(NODE_COLORING_NAVBAR_OPTIONS).removeClass("hidden");
         $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).val(DEFAULT_MAX_LOG_FOLD_CHANGE);
         $(LOG_FOLD_CHANGE_MAX_VALUE_CLASS).addClass("hidden");
+        $(NODE_COLORING_SIDEBAR_BODY).find("input, select, button").prop("disabled, false");
+        $(NODE_COLORING_MENU).removeClass("hidden");
+        $(TOP_DATASET_SELECTION_SIDEBAR).val(grnState.nodeColoring.topDataset);
+        $(BOTTOM_DATASET_SELECTION_SIDEBAR).val(grnState.nodeColoring.bottomDataset);
+        $(AVG_REPLICATE_VALS_TOP_SIDEBAR).prop("checked", grnState.nodeColoring.averageTopDataset);
+        $(AVG_REPLICATE_VALS_BOTTOM_SIDEBAR).prop(
+            "checked",
+            grnState.nodeColoring.averageBottomDataset
+        );
         $(LOG_FOLD_CHANGE_MAX_VALUE_SIDEBAR_BUTTON).addClass("hidden");
         $(LOG_FOLD_CHANGE_MAX_VALUE_HEADER).addClass("hidden");
         if ($(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked")) {
@@ -1022,7 +1031,21 @@ export const updateApp = grnState => {
             }
         }
     } else if (grnState.workbook !== null && !grnState.nodeColoring.nodeColoringEnabled) {
-        $(NODE_COLORING_SIDEBAR_BODY).addClass("hidden");
+        grnState.nodeColoring.showMenu = true;
+        // $(NODE_COLORING_SIDEBAR_BODY).addClass("hidden");
+        $(NODE_COLORING_SIDEBAR_BODY).removeClass("hidden");
+        $(NODE_COLORING_SIDEBAR_BODY).find("input, select, button").prop("disabled", true);
+        // $(`${NODE_COLORING_SIDEBAR_BODY} input, ${NODE_COLORING_SIDEBAR_BODY} button`).prop(
+        //     "disabled",
+        //     true
+        // );
+        $(TOP_DATASET_SELECTION_SIDEBAR).val(grnState.nodeColoring.topDataset);
+        $(BOTTOM_DATASET_SELECTION_SIDEBAR).val(grnState.nodeColoring.bottomDataset);
+        $(AVG_REPLICATE_VALS_TOP_SIDEBAR).prop("checked", grnState.nodeColoring.averageTopDataset);
+        $(AVG_REPLICATE_VALS_BOTTOM_SIDEBAR).prop(
+            "checked",
+            grnState.nodeColoring.averageBottomDataset
+        );
         $(NODE_COLORING_MENU).addClass("disabled");
         $(NODE_COLORING_NAVBAR_OPTIONS).addClass("hidden");
         $(`${NODE_COLORING_TOGGLE_MENU} span`).removeClass("glyphicon-ok");

--- a/web-client-classic/public/js/update-app.js
+++ b/web-client-classic/public/js/update-app.js
@@ -846,9 +846,6 @@ export const updateApp = grnState => {
         // made a choice and we will let the choice stick.
         if (hasExpressionData(grnState.workbook.expression)) {
             resetDatasetDropdownMenus(grnState.workbook);
-            // if (grnState.nodeColoring.nodeColoringEnabled === undefined) {
-            //     grnState.nodeColoring.nodeColoringEnabled = false;
-            // }
 
             if (isNewWorkbook(name)) {
                 grnState.nodeColoring.showMenu = true;
@@ -971,13 +968,17 @@ export const updateApp = grnState => {
             (!grnState.nodeColoring.bottomDataSameAsTop &&
                 grnState.workbook.expression[grnState.nodeColoring.bottomDataset] === undefined)
         ) {
+            updaters.removeNodeColoring();
             resetDatasetDropdownMenus(grnState.workbook);
         }
 
         grnState.nodeColoring.showMenu = true;
-        grnState.nodeColoring.topDataset = grnState.nodeColoring.topDataset || "Dahlquist_2018_wt";
-        grnState.nodeColoring.bottomDataset =
-            grnState.nodeColoring.bottomDataset || "Dahlquist_2018_wt";
+        grnState.nodeColoring.topDataset = grnState.nodeColoring.topDataset
+            ? grnState.nodeColoring.topDataset
+            : "Dahlquist_2018_wt";
+        grnState.nodeColoring.bottomDataset = grnState.nodeColoring.bottomDataset
+            ? grnState.nodeColoring.bottomDataset
+            : "Dahlquist_2018_wt";
 
         $(NODE_COLORING_TOGGLE_SIDEBAR).prop("checked", true);
         $(`${NODE_COLORING_TOGGLE_MENU} span`).addClass("glyphicon-ok");


### PR DESCRIPTION


Pull Request Checklist
- [x] GitHub Actions C.I. build passes
- [x] All five Demos look as expected when loaded
- [x] Reload works as expected
- [x] Load an Excel file (GRN and PPI)
- [x] Load a SIF file (GRN and PPI)
- [x] Load a GraphML file (GRN)
- [x] Loading file with Error brings up error modal, and it looks as expected
- [x] Loading file with Warning brings up warnings modal
- [x] Loading a network from the database looks as expected when loaded (GRN and PPI)
- [x] Network can be exported to SIF (GRN and PPI) and GraphML (GRN-only)
- [x] Network, Expression data, and Additional Sheets can be exported to Excel
- [x] Image can be exported to PNG, SVG and PDF
- [x] Print works as expected
- [x] Restrict graph to viewport works as expected (check/uncheck)
- [x] Viewport Size Changing works as expected (small/medium/large/fit)
- [x] Toggle between Grid Layout and Force Graph Layout works as expected
- [x] Force Graph Parameter Sliders change the number above them and have an effect on the graph
- [x] Locking/Unlocking/Resetting/Undo Resetting the force graph parameters works as expected
- [x] Enabling and disabling node coloring works as expected
- [x] Node coloring options work as expected (selection top/bottom dataset, averaging values, changing max value)
- [x] Weighted graph loaded with the "Enable Edge Coloring" option checked appears as expected
- [x] Hide/Show Weights works as expected (always/never/upon mouseover)
- [x] Edge Weight Normalization Factor can be changed (set/reset)
- [x] Gray Edge Threshold can be changed, slider changes the number and has an effect on the graph
- [x] Checking Show Gray Edges as Dashed works as expected (check/uncheck)
- [x] D-pad left/right/top/bottom/center works as expected
- [x] Zoom slider changes number and has effect on graph (viewport and menu)
- [ ] Right click on a node opens gene page, page is populated with correct data (currently broken, though)
