### PR TITLE
Fixed warnings for property undefined error

### DIFF
--- a/server/controllers/network-sheet-parser.js
+++ b/server/controllers/network-sheet-parser.js
@@ -98,7 +98,6 @@ var parseNetworkSheet = function (sheet, network) {
     try {
         cellA1 = sheet.data[0][0];
     } catch (err) {
-        addError(network, constants.errors.idLabelError(sheet.name));
         return network;
     }
 

--- a/server/controllers/spreadsheet-controller.js
+++ b/server/controllers/spreadsheet-controller.js
@@ -210,7 +210,15 @@ var crossSheetInteractions = function (workbookFile) {
 
     additionalData.meta.data.workbookType = parseNetworkSheet.workbookType(workbookFile);
     if (additionalData.meta.data.workbookType === undefined) {
-        addError(workbook, constants.errors.missingNetworkError);
+        let networkErrorPresent;
+        for (let i = 0; i < workbook.errors.length; i++) {
+            if (workbook.errors[i].errorCode === "MISSING_NETWORK") {
+                networkErrorPresent = true;
+            }
+        }
+        if (!networkErrorPresent) {
+            addError(workbook, constants.errors.missingNetworkError);
+        }
         additionalData.meta.data.workbookType = NETWORK_GRN_MODE;
     } else if (!supportWorkbookType(additionalData.meta.data.workbookType)) {
         addWarning(

--- a/test/expression-data-import-tests.js
+++ b/test/expression-data-import-tests.js
@@ -163,7 +163,7 @@ describe("expression-data-import-tests", function () {
         it("should return an error with network sheet", function () {
             test.emptyNetworkWorkbookError(
                 "test-files/expression-data-test-sheets/empty-network-xlsx-with-network-tab.xlsx",
-                2
+                1
             );
         });
 


### PR DESCRIPTION
Updated the warnings to not be duplicated as well as made it so that only a missing network error displays when a blank sheet is entered.