### PR TITLE
export excel checkboxes do not reset

### DIFF
--- a/web-client-classic/public/js/upload.js
+++ b/web-client-classic/public/js/upload.js
@@ -517,14 +517,17 @@ export const upload = function () {
     `;
     };
 
-    const createHTMLforSheets = (source, savedSheets) => {
+    const createHTMLforSheets = (source, checkedStateByValue) => {
         $(".export-excel-workbook-sheet-option").remove();
 
         const getCheckedAttr = (sheetValue, defaultState = true) => {
-            if (savedSheets) {
-                return savedSheets.includes(sheetValue) ? 'checked="true"' : "";
-            }
-            return defaultState ? 'checked="true"' : "";
+            return Object.prototype.hasOwnProperty.call(checkedStateByValue, sheetValue)
+                ? checkedStateByValue[sheetValue]
+                    ? 'checked="true"'
+                    : ""
+                : defaultState
+                  ? 'checked="true"'
+                  : "";
         };
 
         const sources = [
@@ -689,7 +692,7 @@ export const upload = function () {
         return result;
     };
 
-    var handleWorkbookSheetCheckboxBehaviour = () => {
+    var handleWorkbookSheetCheckboxBehaviour = checkedStateByValue => {
         const syncSelectAll = () => {
             const selectAll = $("#exportExcelWorkbookSheet-All");
             if (!selectAll.length) return;
@@ -701,42 +704,29 @@ export const upload = function () {
 
         $("input[name=workbookSheets]")
             .not($("#exportExcelWorkbookSheet-All"))
-            .on("click", () => {
+            .on("click", function () {
+                checkedStateByValue[this.value] = this.checked;
                 syncSelectAll();
-
-                let anyExpressionChecked = false;
-                for (let i in allSheets) {
-                    if (
-                        typeof allSheets[i] === "object" &&
-                        allSheets[i].id !== "exportExcelWorkbookSheet-All" &&
-                        allSheets[i].checked &&
-                        allSheets[i].value &&
-                        (allSheets[i].value.includes("expression") ||
-                            allSheets[i].value.includes("sigma"))
-                    ) {
-                        anyExpressionChecked = true;
-                        break;
-                    }
-                }
-                if (!anyExpressionChecked) {
-                    $("#exportExcelExpressionSource-noneRadio").val("none").trigger("change");
-                }
             });
+
         $("#exportExcelWorkbookSheet-All").on("click", () => {
             const allSheets = $("input[name=workbookSheets]").not(":disabled");
             const selectAll = $("#exportExcelWorkbookSheet-All");
             for (let i in allSheets) {
                 if (typeof allSheets[i] === "object") {
                     allSheets[i].checked = selectAll[0].checked;
+                    checkedStateByValue[allSheets[i].value] = selectAll[0].checked;
                 }
             }
         });
         syncSelectAll();
     };
 
-    const handleExpressionSheetsFromSource = function (source, savedSheets) {
-        $("#export-excel-workbook-sheet-list").append(createHTMLforSheets(source, savedSheets));
-        handleWorkbookSheetCheckboxBehaviour();
+    const handleExpressionSheetsFromSource = function (source, checkedStateByValue) {
+        $("#export-excel-workbook-sheet-list").append(
+            createHTMLforSheets(source, checkedStateByValue)
+        );
+        handleWorkbookSheetCheckboxBehaviour(checkedStateByValue);
         $("#Export-Excel-Button").off("click");
         $("#Export-Excel-Button").on(
             "click",
@@ -758,16 +748,9 @@ export const upload = function () {
                 source = "userInput";
             }
 
-            const selectedSheetsBySource = {};
+            const checkedStateByValue = {};
 
-            const saveCurrentState = () => {
-                selectedSheetsBySource[source] = [];
-                $("input[name='workbookSheets']:checked").each(function () {
-                    selectedSheetsBySource[source].push($(this).val());
-                });
-            };
-
-            handleExpressionSheetsFromSource(source);
+            handleExpressionSheetsFromSource(source, checkedStateByValue);
 
             $("#export-excel-workbook-sheet-list").off("change", "#expressionSourceDropdown");
             $("#export-excel-workbook-sheet-list").on(
@@ -776,10 +759,9 @@ export const upload = function () {
                 function () {
                     const selectedValue = $(this).val();
                     if (selectedValue !== source) {
-                        saveCurrentState();
                         source = selectedValue;
                         $(".export-excel-workbook-sheet-option-subheader").remove();
-                        handleExpressionSheetsFromSource(source, selectedSheetsBySource[source]);
+                        handleExpressionSheetsFromSource(source, checkedStateByValue);
                     }
                 }
             );


### PR DESCRIPTION

Pull Request Checklist
- [x] GitHub Actions C.I. build passes
- [x] All five Demos look as expected when loaded
- [x] Reload works as expected
- [x] Load an Excel file (GRN and PPI)
- [x] Load a SIF file (GRN and PPI)
- [x] Load a GraphML file (GRN)
- [x] Loading file with Error brings up error modal, and it looks as expected
- [x] Loading file with Warning brings up warnings modal
- [x] Loading a network from the database looks as expected when loaded (GRN and PPI)
- [x] Network can be exported to SIF (GRN and PPI) and GraphML (GRN-only)
- [x] Network, Expression data, and Additional Sheets can be exported to Excel
- [x] Image can be exported to PNG, SVG and PDF
- [x] Print works as expected
- [x] Restrict graph to viewport works as expected (check/uncheck)
- [x] Viewport Size Changing works as expected (small/medium/large/fit)
- [x] Toggle between Grid Layout and Force Graph Layout works as expected
- [x] Force Graph Parameter Sliders change the number above them and have an effect on the graph
- [x] Locking/Unlocking/Resetting/Undo Resetting the force graph parameters works as expected
- [x] Enabling and disabling node coloring works as expected
- [x] Node coloring options work as expected (selection top/bottom dataset, averaging values, changing max value)
- [x] Weighted graph loaded with the "Enable Edge Coloring" option checked appears as expected
- [x] Hide/Show Weights works as expected (always/never/upon mouseover)
- [x] Edge Weight Normalization Factor can be changed (set/reset)
- [x] Gray Edge Threshold can be changed, slider changes the number and has an effect on the graph
- [x] Checking Show Gray Edges as Dashed works as expected (check/uncheck)
- [x] D-pad left/right/top/bottom/center works as expected
- [x] Zoom slider changes number and has effect on graph (viewport and menu)
- [ ] Right click on a node opens gene page, page is populated with correct data (currently broken, though)
